### PR TITLE
feat: add onReady event

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
+++ b/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
@@ -28,7 +28,14 @@ interface LuggGoogleMapViewEventDelegate {
     zoom: Float,
     gesture: Boolean
   )
-  fun onCameraIdle(view: LuggGoogleMapView, latitude: Double, longitude: Double, zoom: Float, gesture: Boolean)
+  fun onCameraIdle(
+    view: LuggGoogleMapView,
+    latitude: Double,
+    longitude: Double,
+    zoom: Float,
+    gesture: Boolean
+  )
+  fun onReady(view: LuggGoogleMapView)
 }
 
 @SuppressLint("ViewConstructor")
@@ -159,6 +166,8 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
     applyPadding()
     processPendingMarkers()
     processPendingPolylines()
+
+    eventDelegate?.onReady(this)
   }
 
   override fun onCameraMoveStarted(reason: Int) {

--- a/android/src/main/java/com/luggmaps/LuggGoogleMapViewManager.kt
+++ b/android/src/main/java/com/luggmaps/LuggGoogleMapViewManager.kt
@@ -5,7 +5,6 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.ThemedReactContext
-import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
@@ -14,6 +13,8 @@ import com.facebook.react.viewmanagers.LuggGoogleMapViewManagerInterface
 import com.google.android.gms.maps.model.LatLng
 import com.luggmaps.events.CameraIdleEvent
 import com.luggmaps.events.CameraMoveEvent
+import com.luggmaps.events.ReadyEvent
+import com.luggmaps.extensions.dispatchEvent
 
 @ReactModule(name = LuggGoogleMapViewManager.NAME)
 class LuggGoogleMapViewManager :
@@ -35,7 +36,8 @@ class LuggGoogleMapViewManager :
   override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any> =
     mapOf(
       "topCameraMove" to mapOf("registrationName" to "onCameraMove"),
-      "topCameraIdle" to mapOf("registrationName" to "onCameraIdle")
+      "topCameraIdle" to mapOf("registrationName" to "onCameraIdle"),
+      "topReady" to mapOf("registrationName" to "onReady")
     )
 
   override fun onCameraMove(
@@ -45,19 +47,21 @@ class LuggGoogleMapViewManager :
     zoom: Float,
     gesture: Boolean
   ) {
-    val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(
-      view.context as ThemedReactContext,
-      view.id
-    )
-    eventDispatcher?.dispatchEvent(CameraMoveEvent(UIManagerHelper.getSurfaceId(view), view.id, latitude, longitude, zoom, gesture))
+    view.dispatchEvent(CameraMoveEvent(view, latitude, longitude, zoom, gesture))
   }
 
-  override fun onCameraIdle(view: LuggGoogleMapView, latitude: Double, longitude: Double, zoom: Float, gesture: Boolean) {
-    val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(
-      view.context as ThemedReactContext,
-      view.id
-    )
-    eventDispatcher?.dispatchEvent(CameraIdleEvent(UIManagerHelper.getSurfaceId(view), view.id, latitude, longitude, zoom, gesture))
+  override fun onCameraIdle(
+    view: LuggGoogleMapView,
+    latitude: Double,
+    longitude: Double,
+    zoom: Float,
+    gesture: Boolean
+  ) {
+    view.dispatchEvent(CameraIdleEvent(view, latitude, longitude, zoom, gesture))
+  }
+
+  override fun onReady(view: LuggGoogleMapView) {
+    view.dispatchEvent(ReadyEvent(view))
   }
 
   @ReactProp(name = "mapId")

--- a/android/src/main/java/com/luggmaps/events/CameraIdleEvent.kt
+++ b/android/src/main/java/com/luggmaps/events/CameraIdleEvent.kt
@@ -1,16 +1,17 @@
 package com.luggmaps.events
 
+import android.view.View
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
 
 class CameraIdleEvent(
-  surfaceId: Int,
-  viewId: Int,
+  view: View,
   private val latitude: Double,
   private val longitude: Double,
   private val zoom: Float,
   private val gesture: Boolean
-) : Event<CameraIdleEvent>(surfaceId, viewId) {
+) : Event<CameraIdleEvent>(UIManagerHelper.getSurfaceId(view), view.id) {
   override fun getEventName() = "topCameraIdle"
 
   override fun getEventData() =

--- a/android/src/main/java/com/luggmaps/events/CameraMoveEvent.kt
+++ b/android/src/main/java/com/luggmaps/events/CameraMoveEvent.kt
@@ -1,16 +1,17 @@
 package com.luggmaps.events
 
+import android.view.View
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
 
 class CameraMoveEvent(
-  surfaceId: Int,
-  viewId: Int,
+  view: View,
   private val latitude: Double,
   private val longitude: Double,
   private val zoom: Float,
   private val gesture: Boolean
-) : Event<CameraMoveEvent>(surfaceId, viewId) {
+) : Event<CameraMoveEvent>(UIManagerHelper.getSurfaceId(view), view.id) {
   override fun getEventName() = "topCameraMove"
 
   override fun getEventData() =

--- a/android/src/main/java/com/luggmaps/events/ReadyEvent.kt
+++ b/android/src/main/java/com/luggmaps/events/ReadyEvent.kt
@@ -1,0 +1,12 @@
+package com.luggmaps.events
+
+import android.view.View
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.Event
+
+class ReadyEvent(view: View) : Event<ReadyEvent>(UIManagerHelper.getSurfaceId(view), view.id) {
+  override fun getEventName() = "topReady"
+
+  override fun getEventData() = Arguments.createMap()
+}

--- a/android/src/main/java/com/luggmaps/extensions/ViewExtensions.kt
+++ b/android/src/main/java/com/luggmaps/extensions/ViewExtensions.kt
@@ -1,0 +1,14 @@
+package com.luggmaps.extensions
+
+import android.view.View
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.Event
+
+fun View.dispatchEvent(event: Event<*>) {
+  val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(
+    context as ThemedReactContext,
+    id
+  )
+  eventDispatcher?.dispatchEvent(event)
+}

--- a/example/shared/src/Home.tsx
+++ b/example/shared/src/Home.tsx
@@ -28,6 +28,7 @@ import {
 
 export function Home() {
   const mapRef = useRef<MapView>(null);
+  const sheetRef = useRef<TrueSheet>(null);
   const { height: screenHeight } = useWindowDimensions();
   const [provider, setProvider] = useState<MapProvider>('google');
   const [showMap, setShowMap] = useState(true);
@@ -59,6 +60,10 @@ export function Home() {
     },
     [screenHeight]
   );
+
+  const handleMapReady = useCallback(() => {
+    sheetRef.current?.present();
+  }, []);
 
   const addRandomMarker = () => {
     const type = randomFrom(MARKER_TYPES);
@@ -110,16 +115,16 @@ export function Home() {
           provider={provider}
           markers={markers}
           padding={mapPadding}
+          onReady={handleMapReady}
           onCameraMove={handleCameraMove}
           onCameraIdle={handleCameraIdle}
         />
       )}
 
       <TrueSheet
+        ref={sheetRef}
         detents={['auto']}
         dimmed={false}
-        initialDetentIndex={0}
-        initialDetentAnimated={false}
         backgroundBlur="system-material-light"
         dismissible={false}
         grabber={false}

--- a/ios/LuggAppleMapView.mm
+++ b/ios/LuggAppleMapView.mm
@@ -1,10 +1,11 @@
 #import "LuggAppleMapView.h"
+#import "LuggMapWrapperView.h"
 #import "LuggMarkerView.h"
 #import "LuggPolylineView.h"
-#import "LuggMapWrapperView.h"
 #import "core/MKPolylineAnimator.h"
 #import "events/CameraIdleEvent.h"
 #import "events/CameraMoveEvent.h"
+#import "events/ReadyEvent.h"
 #import "extensions/MKMapView+Zoom.h"
 
 #import <react/renderer/components/RNMapsSpec/ComponentDescriptors.h>
@@ -31,14 +32,15 @@ using namespace luggmaps::events;
 @implementation LuggAppleMapViewContent
 @end
 
-@interface LuggAppleMapView () <
-    RCTLuggAppleMapViewViewProtocol, MKMapViewDelegate,
-    LuggMarkerViewDelegate, LuggPolylineViewDelegate>
+@interface LuggAppleMapView () <RCTLuggAppleMapViewViewProtocol,
+                                MKMapViewDelegate, LuggMarkerViewDelegate,
+                                LuggPolylineViewDelegate>
 @end
 
 @implementation LuggAppleMapView {
   LuggAppleMapViewContent *_mapView;
   LuggMapWrapperView *_mapWrapperView;
+  BOOL _isMapReady;
   BOOL _isDragging;
 }
 
@@ -80,8 +82,7 @@ using namespace luggmaps::events;
 
     [self markerViewDidUpdate:markerView];
   } else if ([childComponentView isKindOfClass:[LuggPolylineView class]]) {
-    LuggPolylineView *polylineView =
-        (LuggPolylineView *)childComponentView;
+    LuggPolylineView *polylineView = (LuggPolylineView *)childComponentView;
     polylineView.delegate = self;
     [self addPolylineViewToMap:polylineView];
   }
@@ -104,8 +105,7 @@ using namespace luggmaps::events;
       markerView.marker = nil;
     }
   } else if ([childComponentView isKindOfClass:[LuggPolylineView class]]) {
-    LuggPolylineView *polylineView =
-        (LuggPolylineView *)childComponentView;
+    LuggPolylineView *polylineView = (LuggPolylineView *)childComponentView;
     polylineView.delegate = nil;
     MKPolyline *polyline = (MKPolyline *)polylineView.polyline;
     if (polyline) {
@@ -130,6 +130,7 @@ using namespace luggmaps::events;
   [_mapView removeFromSuperview];
   _mapView = nil;
   _mapWrapperView = nil;
+  _isMapReady = NO;
 }
 
 #pragma mark - Map Initialization
@@ -142,8 +143,8 @@ using namespace luggmaps::events;
   const auto &viewProps =
       *std::static_pointer_cast<LuggAppleMapViewProps const>(_props);
 
-  _mapView = [[LuggAppleMapViewContent alloc]
-      initWithFrame:_mapWrapperView.bounds];
+  _mapView =
+      [[LuggAppleMapViewContent alloc] initWithFrame:_mapWrapperView.bounds];
   _mapView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   _mapView.delegate = self;
@@ -174,6 +175,10 @@ using namespace luggmaps::events;
       [self addPolylineViewToMap:polylineView];
     }
   }
+
+  _isMapReady = YES;
+
+  ReadyEvent::emit<LuggAppleMapViewEventEmitter>(_eventEmitter);
 }
 
 - (void)setCameraWithLatitude:(double)latitude
@@ -367,29 +372,19 @@ using namespace luggmaps::events;
 }
 
 - (void)mapViewDidChangeVisibleRegion:(MKMapView *)mapView {
-  if (_eventEmitter) {
-    auto emitter =
-        std::static_pointer_cast<LuggAppleMapViewEventEmitter const>(
-            _eventEmitter);
-    CameraMoveEvent{mapView.centerCoordinate.latitude,
-                    mapView.centerCoordinate.longitude, mapView.zoomLevel,
-                    _isDragging}
-        .emit(emitter);
-  }
+  CameraMoveEvent{mapView.centerCoordinate.latitude,
+                  mapView.centerCoordinate.longitude, mapView.zoomLevel,
+                  _isDragging}
+      .emit<LuggAppleMapViewEventEmitter>(_eventEmitter);
 }
 
 - (void)mapView:(MKMapView *)mapView regionDidChangeAnimated:(BOOL)animated {
   BOOL wasDragging = _isDragging;
   _isDragging = NO;
-  if (_eventEmitter) {
-    auto emitter =
-        std::static_pointer_cast<LuggAppleMapViewEventEmitter const>(
-            _eventEmitter);
-    CameraIdleEvent{mapView.centerCoordinate.latitude,
-                    mapView.centerCoordinate.longitude, mapView.zoomLevel,
-                    static_cast<bool>(wasDragging)}
-        .emit(emitter);
-  }
+  CameraIdleEvent{mapView.centerCoordinate.latitude,
+                  mapView.centerCoordinate.longitude, mapView.zoomLevel,
+                  static_cast<bool>(wasDragging)}
+      .emit<LuggAppleMapViewEventEmitter>(_eventEmitter);
 }
 
 - (MKAnnotationView *)mapView:(MKMapView *)mapView
@@ -437,8 +432,7 @@ using namespace luggmaps::events;
 - (MKOverlayRenderer *)mapView:(MKMapView *)mapView
             rendererForOverlay:(id<MKOverlay>)overlay {
   if ([overlay isKindOfClass:[MKPolyline class]]) {
-    LuggPolylineView *polylineView =
-        [self findPolylineViewForOverlay:overlay];
+    LuggPolylineView *polylineView = [self findPolylineViewForOverlay:overlay];
     MKPolyline *polyline = (MKPolyline *)overlay;
 
     if (polylineView) {

--- a/ios/LuggGoogleMapView.mm
+++ b/ios/LuggGoogleMapView.mm
@@ -5,6 +5,7 @@
 #import "core/PolylineAnimatorBase.h"
 #import "events/CameraIdleEvent.h"
 #import "events/CameraMoveEvent.h"
+#import "events/ReadyEvent.h"
 
 #import <react/renderer/components/RNMapsSpec/ComponentDescriptors.h>
 #import <react/renderer/components/RNMapsSpec/EventEmitters.h>
@@ -20,9 +21,9 @@ using namespace luggmaps::events;
 
 static NSString *const kDemoMapId = @"DEMO_MAP_ID";
 
-@interface LuggGoogleMapView () <
-    RCTLuggGoogleMapViewViewProtocol, GMSMapViewDelegate,
-    LuggMarkerViewDelegate, LuggPolylineViewDelegate>
+@interface LuggGoogleMapView () <RCTLuggGoogleMapViewViewProtocol,
+                                 GMSMapViewDelegate, LuggMarkerViewDelegate,
+                                 LuggPolylineViewDelegate>
 @end
 
 @implementation LuggGoogleMapView {
@@ -71,8 +72,7 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
     markerView.delegate = self;
     [self syncMarkerView:markerView caller:@"mountChildComponentView"];
   } else if ([childComponentView isKindOfClass:[LuggPolylineView class]]) {
-    LuggPolylineView *polylineView =
-        (LuggPolylineView *)childComponentView;
+    LuggPolylineView *polylineView = (LuggPolylineView *)childComponentView;
     polylineView.delegate = self;
     [self syncPolylineView:polylineView];
   }
@@ -90,8 +90,7 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
       markerView.marker = nil;
     }
   } else if ([childComponentView isKindOfClass:[LuggPolylineView class]]) {
-    LuggPolylineView *polylineView =
-        (LuggPolylineView *)childComponentView;
+    LuggPolylineView *polylineView = (LuggPolylineView *)childComponentView;
     [_polylineAnimators removeObjectForKey:polylineView];
     GMSPolyline *polyline = (GMSPolyline *)polylineView.polyline;
     if (polyline) {
@@ -166,6 +165,8 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
   _isMapReady = YES;
   [self processPendingMarkers];
   [self processPendingPolylines];
+
+  ReadyEvent::emit<LuggGoogleMapViewEventEmitter>(_eventEmitter);
 }
 
 - (GMSMapView *)mapView {
@@ -180,28 +181,18 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
 
 - (void)mapView:(GMSMapView *)mapView
     didChangeCameraPosition:(GMSCameraPosition *)position {
-  if (_eventEmitter) {
-    auto emitter =
-        std::static_pointer_cast<LuggGoogleMapViewEventEmitter const>(
-            _eventEmitter);
-    CameraMoveEvent{position.target.latitude, position.target.longitude,
-                    position.zoom, _isDragging}
-        .emit(emitter);
-  }
+  CameraMoveEvent{position.target.latitude, position.target.longitude,
+                  position.zoom, _isDragging}
+      .emit<LuggGoogleMapViewEventEmitter>(_eventEmitter);
 }
 
 - (void)mapView:(GMSMapView *)mapView
     idleAtCameraPosition:(GMSCameraPosition *)position {
   BOOL wasDragging = _isDragging;
   _isDragging = NO;
-  if (_eventEmitter) {
-    auto emitter =
-        std::static_pointer_cast<LuggGoogleMapViewEventEmitter const>(
-            _eventEmitter);
-    CameraIdleEvent{position.target.latitude, position.target.longitude,
-                    position.zoom, static_cast<bool>(wasDragging)}
-        .emit(emitter);
-  }
+  CameraIdleEvent{position.target.latitude, position.target.longitude,
+                  position.zoom, static_cast<bool>(wasDragging)}
+      .emit<LuggGoogleMapViewEventEmitter>(_eventEmitter);
 }
 
 #pragma mark - PolylineViewDelegate
@@ -222,8 +213,7 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
 
 #pragma mark - Marker Management
 
-- (void)syncMarkerView:(LuggMarkerView *)markerView
-                caller:(NSString *)caller {
+- (void)syncMarkerView:(LuggMarkerView *)markerView caller:(NSString *)caller {
   if (!_mapView) {
     if (![_pendingMarkerViews containsObject:markerView]) {
       [_pendingMarkerViews addObject:markerView];

--- a/ios/events/CameraIdleEvent.h
+++ b/ios/events/CameraIdleEvent.h
@@ -12,7 +12,9 @@ struct CameraIdleEvent {
   bool gesture;
 
   template <typename Emitter>
-  void emit(std::shared_ptr<Emitter const> emitter) const {
+  void emit(const facebook::react::SharedEventEmitter &eventEmitter) const {
+    if (!eventEmitter) return;
+    auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);
     typename Emitter::OnCameraIdle event;
     event.coordinate.latitude = latitude;
     event.coordinate.longitude = longitude;

--- a/ios/events/CameraMoveEvent.h
+++ b/ios/events/CameraMoveEvent.h
@@ -12,7 +12,9 @@ struct CameraMoveEvent {
   bool gesture;
 
   template <typename Emitter>
-  void emit(std::shared_ptr<Emitter const> emitter) const {
+  void emit(const facebook::react::SharedEventEmitter &eventEmitter) const {
+    if (!eventEmitter) return;
+    auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);
     typename Emitter::OnCameraMove event;
     event.coordinate.latitude = latitude;
     event.coordinate.longitude = longitude;

--- a/ios/events/ReadyEvent.h
+++ b/ios/events/ReadyEvent.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#import <react/renderer/components/RNMapsSpec/EventEmitters.h>
+
+namespace luggmaps {
+namespace events {
+
+struct ReadyEvent {
+  template <typename Emitter>
+  static void emit(const facebook::react::SharedEventEmitter &eventEmitter) {
+    if (!eventEmitter) return;
+    auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);
+    typename Emitter::OnReady event;
+    emitter->onReady(event);
+  }
+};
+
+} // namespace events
+} // namespace luggmaps

--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -79,6 +79,7 @@ export class MapView
       padding,
       onCameraMove,
       onCameraIdle,
+      onReady,
       children,
       ...rest
     } = this.props;
@@ -102,6 +103,7 @@ export class MapView
         padding={padding}
         onCameraMove={onCameraMove}
         onCameraIdle={onCameraIdle}
+        onReady={onReady}
       >
         <LuggMapWrapperViewNativeComponent style={StyleSheet.absoluteFill} />
         {children}

--- a/src/MapView.types.ts
+++ b/src/MapView.types.ts
@@ -96,6 +96,10 @@ export interface MapViewProps extends ViewProps {
    */
   onCameraIdle?: (event: NativeSyntheticEvent<CameraEventPayload>) => void;
   /**
+   * Called when map is loaded and ready
+   */
+  onReady?: () => void;
+  /**
    * Map children (markers, polylines, etc.)
    */
   children?: ReactNode;

--- a/src/fabric/LuggAppleMapViewNativeComponent.ts
+++ b/src/fabric/LuggAppleMapViewNativeComponent.ts
@@ -35,6 +35,8 @@ export interface CameraIdleEvent {
   gesture: boolean;
 }
 
+export interface ReadyEvent {}
+
 export interface NativeProps extends ViewProps {
   initialCoordinate?: Coordinate;
   initialZoom?: Double;
@@ -45,6 +47,7 @@ export interface NativeProps extends ViewProps {
   padding?: EdgeInsets;
   onCameraMove?: DirectEventHandler<CameraMoveEvent>;
   onCameraIdle?: DirectEventHandler<CameraIdleEvent>;
+  onReady?: DirectEventHandler<ReadyEvent>;
 }
 
 type ComponentType = HostComponent<NativeProps>;

--- a/src/fabric/LuggGoogleMapViewNativeComponent.ts
+++ b/src/fabric/LuggGoogleMapViewNativeComponent.ts
@@ -35,6 +35,8 @@ export interface CameraIdleEvent {
   gesture: boolean;
 }
 
+export interface ReadyEvent {}
+
 export interface NativeProps extends ViewProps {
   mapId?: string;
   initialCoordinate?: Coordinate;
@@ -46,6 +48,7 @@ export interface NativeProps extends ViewProps {
   padding?: EdgeInsets;
   onCameraMove?: DirectEventHandler<CameraMoveEvent>;
   onCameraIdle?: DirectEventHandler<CameraIdleEvent>;
+  onReady?: DirectEventHandler<ReadyEvent>;
 }
 
 type ComponentType = HostComponent<NativeProps>;


### PR DESCRIPTION
## Summary
Add `onReady` event that fires when the map is loaded and ready.

## Type of Change
- [x] New feature

## Test Plan
Updated example app to present the sheet when map is ready instead of immediately.

## Checklist
- [x] iOS
- [x] Android