### PR TITLE
feat: add minZoom and maxZoom props to MapView

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
+++ b/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
@@ -70,6 +70,10 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
   private var rotateEnabled: Boolean = true
   private var pitchEnabled: Boolean = true
 
+  // Zoom limits
+  private var minZoom: Float? = null
+  private var maxZoom: Float? = null
+
   // Padding
   private var paddingTop: Int = 0
   private var paddingLeft: Int = 0
@@ -163,6 +167,7 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
     map.setOnCameraIdleListener(this)
 
     applyUiSettings()
+    applyZoomLimits()
     applyPadding()
     processPendingMarkers()
     processPendingPolylines()
@@ -193,6 +198,13 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
       isScrollGesturesEnabled = scrollEnabled
       isRotateGesturesEnabled = rotateEnabled
       isTiltGesturesEnabled = pitchEnabled
+    }
+  }
+
+  private fun applyZoomLimits() {
+    googleMap?.apply {
+      minZoom?.let { setMinZoomPreference(it) }
+      maxZoom?.let { setMaxZoomPreference(it) }
     }
   }
 
@@ -397,6 +409,20 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
   fun setPitchEnabled(enabled: Boolean) {
     pitchEnabled = enabled
     googleMap?.uiSettings?.isTiltGesturesEnabled = enabled
+  }
+
+  fun setMinZoom(zoom: Double) {
+    minZoom = if (zoom > 0) zoom.toFloat() else null
+    googleMap?.let { map ->
+      minZoom?.let { map.setMinZoomPreference(it) } ?: map.resetMinMaxZoomPreference()
+    }
+  }
+
+  fun setMaxZoom(zoom: Double) {
+    maxZoom = if (zoom > 0) zoom.toFloat() else null
+    googleMap?.let { map ->
+      maxZoom?.let { map.setMaxZoomPreference(it) } ?: map.resetMinMaxZoomPreference()
+    }
   }
 
   fun setMapPadding(top: Int, left: Int, bottom: Int, right: Int) {

--- a/android/src/main/java/com/luggmaps/LuggGoogleMapViewManager.kt
+++ b/android/src/main/java/com/luggmaps/LuggGoogleMapViewManager.kt
@@ -103,6 +103,16 @@ class LuggGoogleMapViewManager :
     view.setPitchEnabled(value)
   }
 
+  @ReactProp(name = "minZoom")
+  override fun setMinZoom(view: LuggGoogleMapView, value: Double) {
+    view.setMinZoom(value)
+  }
+
+  @ReactProp(name = "maxZoom")
+  override fun setMaxZoom(view: LuggGoogleMapView, value: Double) {
+    view.setMaxZoom(value)
+  }
+
   @ReactProp(name = "padding")
   override fun setPadding(view: LuggGoogleMapView, value: ReadableMap?) {
     value?.let {

--- a/ios/LuggAppleMapView.mm
+++ b/ios/LuggAppleMapView.mm
@@ -42,6 +42,8 @@ using namespace luggmaps::events;
   LuggMapWrapperView *_mapWrapperView;
   BOOL _isMapReady;
   BOOL _isDragging;
+  double _minZoom;
+  double _maxZoom;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider {
@@ -154,6 +156,10 @@ using namespace luggmaps::events;
   _mapView.rotateEnabled = viewProps.rotateEnabled;
   _mapView.pitchEnabled = viewProps.pitchEnabled;
 
+  _minZoom = viewProps.minZoom;
+  _maxZoom = viewProps.maxZoom;
+  [self applyZoomRange];
+
   [_mapWrapperView addSubview:_mapView];
 
   [self setCameraWithLatitude:viewProps.initialCoordinate.latitude
@@ -190,6 +196,24 @@ using namespace luggmaps::events;
   [_mapView setCenterCoordinate:center zoomLevel:zoom animated:animated];
 }
 
+- (CLLocationDistance)cameraDistanceForZoomLevel:(double)zoomLevel {
+  // Approximate conversion: at zoom 0, altitude ~128M km
+  // Each zoom level halves the altitude
+  return 128000000.0 / pow(2, zoomLevel);
+}
+
+- (void)applyZoomRange {
+  if (!_mapView) return;
+
+  CLLocationDistance minDistance = _maxZoom > 0 ? [self cameraDistanceForZoomLevel:_maxZoom] : 0;
+  CLLocationDistance maxDistance = _minZoom > 0 ? [self cameraDistanceForZoomLevel:_minZoom] : -1;
+
+  MKMapViewCameraZoomRange *zoomRange =
+      [[MKMapViewCameraZoomRange alloc] initWithMinCenterCoordinateDistance:minDistance
+                                              maxCenterCoordinateDistance:maxDistance];
+  _mapView.cameraZoomRange = zoomRange;
+}
+
 - (MKMapView *)mapView {
   return _mapView;
 }
@@ -209,6 +233,10 @@ using namespace luggmaps::events;
     _mapView.layoutMargins = UIEdgeInsetsMake(
         newViewProps.padding.top, newViewProps.padding.left,
         newViewProps.padding.bottom, newViewProps.padding.right);
+
+    _minZoom = newViewProps.minZoom;
+    _maxZoom = newViewProps.maxZoom;
+    [self applyZoomRange];
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/ios/LuggGoogleMapView.mm
+++ b/ios/LuggGoogleMapView.mm
@@ -160,6 +160,13 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
   _mapView.settings.rotateGestures = viewProps.rotateEnabled;
   _mapView.settings.tiltGestures = viewProps.pitchEnabled;
 
+  if (viewProps.minZoom > 0) {
+    [_mapView setMinZoom:(float)viewProps.minZoom maxZoom:_mapView.maxZoom];
+  }
+  if (viewProps.maxZoom > 0) {
+    [_mapView setMinZoom:_mapView.minZoom maxZoom:(float)viewProps.maxZoom];
+  }
+
   [_mapWrapperView addSubview:_mapView];
 
   _isMapReady = YES;
@@ -359,6 +366,10 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
     _mapView.padding = UIEdgeInsetsMake(
         newViewProps.padding.top, newViewProps.padding.left,
         newViewProps.padding.bottom, newViewProps.padding.right);
+
+    float minZoom = newViewProps.minZoom > 0 ? (float)newViewProps.minZoom : _mapView.minZoom;
+    float maxZoom = newViewProps.maxZoom > 0 ? (float)newViewProps.maxZoom : _mapView.maxZoom;
+    [_mapView setMinZoom:minZoom maxZoom:maxZoom];
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -72,6 +72,8 @@ export class MapView
       mapId,
       initialCoordinate,
       initialZoom,
+      minZoom,
+      maxZoom,
       zoomEnabled,
       scrollEnabled,
       rotateEnabled,
@@ -96,6 +98,8 @@ export class MapView
         mapId={mapId}
         initialCoordinate={initialCoordinate}
         initialZoom={initialZoom}
+        minZoom={minZoom}
+        maxZoom={maxZoom}
         zoomEnabled={zoomEnabled}
         scrollEnabled={scrollEnabled}
         rotateEnabled={rotateEnabled}

--- a/src/MapView.types.ts
+++ b/src/MapView.types.ts
@@ -64,6 +64,14 @@ export interface MapViewProps extends ViewProps {
    */
   initialZoom?: number;
   /**
+   * Minimum zoom level
+   */
+  minZoom?: number;
+  /**
+   * Maximum zoom level
+   */
+  maxZoom?: number;
+  /**
    * Enable zoom gestures
    * @default true
    */

--- a/src/fabric/LuggAppleMapViewNativeComponent.ts
+++ b/src/fabric/LuggAppleMapViewNativeComponent.ts
@@ -40,6 +40,8 @@ export interface ReadyEvent {}
 export interface NativeProps extends ViewProps {
   initialCoordinate?: Coordinate;
   initialZoom?: Double;
+  minZoom?: Double;
+  maxZoom?: Double;
   zoomEnabled?: boolean;
   scrollEnabled?: boolean;
   rotateEnabled?: boolean;

--- a/src/fabric/LuggGoogleMapViewNativeComponent.ts
+++ b/src/fabric/LuggGoogleMapViewNativeComponent.ts
@@ -41,6 +41,8 @@ export interface NativeProps extends ViewProps {
   mapId?: string;
   initialCoordinate?: Coordinate;
   initialZoom?: Double;
+  minZoom?: Double;
+  maxZoom?: Double;
   zoomEnabled?: boolean;
   scrollEnabled?: boolean;
   rotateEnabled?: boolean;


### PR DESCRIPTION
## Summary

Add `minZoom` and `maxZoom` props to MapView component to constrain camera zoom levels.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Tested on iOS (Apple Maps & Google Maps) and Android by setting minZoom/maxZoom props and verifying zoom constraints are applied.

## Checklist

- [x] iOS
- [x] Android
- [ ] Web