### PR TITLE
feat: add userLocationEnabled prop

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
+++ b/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
@@ -69,6 +69,7 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
   private var scrollEnabled: Boolean = true
   private var rotateEnabled: Boolean = true
   private var pitchEnabled: Boolean = true
+  private var userLocationEnabled: Boolean = false
 
   // Zoom limits
   private var minZoom: Float? = null
@@ -169,6 +170,7 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
     applyUiSettings()
     applyZoomLimits()
     applyPadding()
+    applyUserLocation()
     processPendingMarkers()
     processPendingPolylines()
 
@@ -210,6 +212,13 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
 
   private fun applyPadding() {
     googleMap?.setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom)
+  }
+
+  @SuppressLint("MissingPermission")
+  private fun applyUserLocation() {
+    val hasPermission = context.checkSelfPermission(android.Manifest.permission.ACCESS_FINE_LOCATION) == android.content.pm.PackageManager.PERMISSION_GRANTED ||
+      context.checkSelfPermission(android.Manifest.permission.ACCESS_COARSE_LOCATION) == android.content.pm.PackageManager.PERMISSION_GRANTED
+    googleMap?.isMyLocationEnabled = userLocationEnabled && hasPermission
   }
 
   // endregion
@@ -409,6 +418,11 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
   fun setPitchEnabled(enabled: Boolean) {
     pitchEnabled = enabled
     googleMap?.uiSettings?.isTiltGesturesEnabled = enabled
+  }
+
+  fun setUserLocationEnabled(enabled: Boolean) {
+    userLocationEnabled = enabled
+    applyUserLocation()
   }
 
   fun setMinZoom(zoom: Double) {

--- a/android/src/main/java/com/luggmaps/LuggGoogleMapViewManager.kt
+++ b/android/src/main/java/com/luggmaps/LuggGoogleMapViewManager.kt
@@ -103,6 +103,11 @@ class LuggGoogleMapViewManager :
     view.setPitchEnabled(value)
   }
 
+  @ReactProp(name = "userLocationEnabled", defaultBoolean = false)
+  override fun setUserLocationEnabled(view: LuggGoogleMapView, value: Boolean) {
+    view.setUserLocationEnabled(value)
+  }
+
   @ReactProp(name = "minZoom")
   override fun setMinZoom(view: LuggGoogleMapView, value: Double) {
     view.setMinZoom(value)

--- a/example/bare/android/app/src/main/AndroidManifest.xml
+++ b/example/bare/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
       android:name=".MainApplication"

--- a/example/expo/app.json
+++ b/example/expo/app.json
@@ -30,6 +30,12 @@
           "iosGoogleMapsApiKey": "AIzaSyBeaou3cjmq_BED6HlTRdg5fSyArUCzoTM",
           "androidGoogleMapsApiKey": "AIzaSyBeaou3cjmq_BED6HlTRdg5fSyArUCzoTM"
         }
+      ],
+      [
+        "expo-location",
+        {
+          "locationWhenInUsePermission": "Show current location on map"
+        }
       ]
     ]
   }

--- a/example/expo/package.json
+++ b/example/expo/package.json
@@ -14,6 +14,7 @@
     "@lugg/maps": "workspace:*",
     "@lugg/shared-example": "workspace:*",
     "expo": "~54.0.0",
+    "expo-location": "~18.1.0",
     "expo-status-bar": "~3.0.0",
     "react": "19.1.0",
     "react-native": "0.81.5",

--- a/example/shared/src/Home.tsx
+++ b/example/shared/src/Home.tsx
@@ -25,11 +25,13 @@ import {
   MARKER_TYPES,
   INITIAL_MARKERS,
 } from './markers';
+import { useLocationPermission } from './useLocationPermission';
 
 export function Home() {
   const mapRef = useRef<MapView>(null);
   const sheetRef = useRef<TrueSheet>(null);
   const { height: screenHeight } = useWindowDimensions();
+  const locationPermission = useLocationPermission();
   const [provider, setProvider] = useState<MapProvider>('google');
   const [showMap, setShowMap] = useState(true);
   const [markers, setMarkers] = useState(INITIAL_MARKERS);
@@ -115,6 +117,7 @@ export function Home() {
           provider={provider}
           markers={markers}
           padding={mapPadding}
+          userLocationEnabled={locationPermission}
           onReady={handleMapReady}
           onCameraMove={handleCameraMove}
           onCameraIdle={handleCameraIdle}

--- a/example/shared/src/useLocationPermission.ts
+++ b/example/shared/src/useLocationPermission.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { Platform, PermissionsAndroid } from 'react-native';
+
+export function useLocationPermission() {
+  const [granted, setGranted] = useState(false);
+
+  useEffect(() => {
+    const request = async () => {
+      if (Platform.OS === 'ios') {
+        setGranted(true);
+        return;
+      }
+
+      const result = await PermissionsAndroid.request(
+        PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION
+      );
+      setGranted(result === PermissionsAndroid.RESULTS.GRANTED);
+    };
+
+    request();
+  }, []);
+
+  return granted;
+}

--- a/ios/LuggAppleMapView.mm
+++ b/ios/LuggAppleMapView.mm
@@ -155,6 +155,7 @@ using namespace luggmaps::events;
   _mapView.scrollEnabled = viewProps.scrollEnabled;
   _mapView.rotateEnabled = viewProps.rotateEnabled;
   _mapView.pitchEnabled = viewProps.pitchEnabled;
+  _mapView.showsUserLocation = viewProps.userLocationEnabled;
 
   _minZoom = viewProps.minZoom;
   _maxZoom = viewProps.maxZoom;
@@ -208,8 +209,8 @@ using namespace luggmaps::events;
   CLLocationDistance minDistance = _maxZoom > 0 ? [self cameraDistanceForZoomLevel:_maxZoom] : 0;
   CLLocationDistance maxDistance = _minZoom > 0 ? [self cameraDistanceForZoomLevel:_minZoom] : -1;
 
-  MKMapViewCameraZoomRange *zoomRange =
-      [[MKMapViewCameraZoomRange alloc] initWithMinCenterCoordinateDistance:minDistance
+  MKMapCameraZoomRange *zoomRange =
+      [[MKMapCameraZoomRange alloc] initWithMinCenterCoordinateDistance:minDistance
                                               maxCenterCoordinateDistance:maxDistance];
   _mapView.cameraZoomRange = zoomRange;
 }
@@ -230,6 +231,7 @@ using namespace luggmaps::events;
     _mapView.scrollEnabled = newViewProps.scrollEnabled;
     _mapView.rotateEnabled = newViewProps.rotateEnabled;
     _mapView.pitchEnabled = newViewProps.pitchEnabled;
+    _mapView.showsUserLocation = newViewProps.userLocationEnabled;
     _mapView.layoutMargins = UIEdgeInsetsMake(
         newViewProps.padding.top, newViewProps.padding.left,
         newViewProps.padding.bottom, newViewProps.padding.right);

--- a/ios/LuggGoogleMapView.mm
+++ b/ios/LuggGoogleMapView.mm
@@ -159,6 +159,7 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
   _mapView.settings.scrollGestures = viewProps.scrollEnabled;
   _mapView.settings.rotateGestures = viewProps.rotateEnabled;
   _mapView.settings.tiltGestures = viewProps.pitchEnabled;
+  _mapView.myLocationEnabled = viewProps.userLocationEnabled;
 
   if (viewProps.minZoom > 0) {
     [_mapView setMinZoom:(float)viewProps.minZoom maxZoom:_mapView.maxZoom];
@@ -363,6 +364,7 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
     _mapView.settings.scrollGestures = newViewProps.scrollEnabled;
     _mapView.settings.rotateGestures = newViewProps.rotateEnabled;
     _mapView.settings.tiltGestures = newViewProps.pitchEnabled;
+    _mapView.myLocationEnabled = newViewProps.userLocationEnabled;
     _mapView.padding = UIEdgeInsetsMake(
         newViewProps.padding.top, newViewProps.padding.left,
         newViewProps.padding.bottom, newViewProps.padding.right);

--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -79,6 +79,7 @@ export class MapView
       rotateEnabled,
       pitchEnabled,
       padding,
+      userLocationEnabled,
       onCameraMove,
       onCameraIdle,
       onReady,
@@ -105,6 +106,7 @@ export class MapView
         rotateEnabled={rotateEnabled}
         pitchEnabled={pitchEnabled}
         padding={padding}
+        userLocationEnabled={userLocationEnabled}
         onCameraMove={onCameraMove}
         onCameraIdle={onCameraIdle}
         onReady={onReady}

--- a/src/MapView.types.ts
+++ b/src/MapView.types.ts
@@ -96,6 +96,12 @@ export interface MapViewProps extends ViewProps {
    */
   padding?: EdgeInsets;
   /**
+   * Show current user location on the map.
+   * Requires location permission to be granted, otherwise silently ignored.
+   * @default false
+   */
+  userLocationEnabled?: boolean;
+  /**
    * Called when camera moves
    */
   onCameraMove?: (event: NativeSyntheticEvent<CameraEventPayload>) => void;

--- a/src/fabric/LuggAppleMapViewNativeComponent.ts
+++ b/src/fabric/LuggAppleMapViewNativeComponent.ts
@@ -47,6 +47,7 @@ export interface NativeProps extends ViewProps {
   rotateEnabled?: boolean;
   pitchEnabled?: boolean;
   padding?: EdgeInsets;
+  userLocationEnabled?: boolean;
   onCameraMove?: DirectEventHandler<CameraMoveEvent>;
   onCameraIdle?: DirectEventHandler<CameraIdleEvent>;
   onReady?: DirectEventHandler<ReadyEvent>;

--- a/src/fabric/LuggGoogleMapViewNativeComponent.ts
+++ b/src/fabric/LuggGoogleMapViewNativeComponent.ts
@@ -48,6 +48,7 @@ export interface NativeProps extends ViewProps {
   rotateEnabled?: boolean;
   pitchEnabled?: boolean;
   padding?: EdgeInsets;
+  userLocationEnabled?: boolean;
   onCameraMove?: DirectEventHandler<CameraMoveEvent>;
   onCameraIdle?: DirectEventHandler<CameraIdleEvent>;
   onReady?: DirectEventHandler<ReadyEvent>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3338,6 +3338,7 @@ __metadata:
     "@types/react": "npm:~19.1.0"
     babel-preset-expo: "npm:~13.2.0"
     expo: "npm:~54.0.0"
+    expo-location: "npm:~18.1.0"
     expo-status-bar: "npm:~3.0.0"
     react: "npm:19.1.0"
     react-native: "npm:0.81.5"
@@ -7575,6 +7576,15 @@ __metadata:
     expo: "*"
     react: "*"
   checksum: 10c0/23064b18285498e70be0aa525dc875cc809fc723b9a101d51e4721a09b1460eb041c73ebeb6d51e9175bb4c9b7a668bc08a48b99ebddac4cfaadb5a47194d329
+  languageName: node
+  linkType: hard
+
+"expo-location@npm:~18.1.0":
+  version: 18.1.6
+  resolution: "expo-location@npm:18.1.6"
+  peerDependencies:
+    expo: "*"
+  checksum: 10c0/94ae7ae5ca144f2cd327fc26f76355783e81b5454b6328a5d127511251e1b09ff04e70084f314dff825a91211338fb801434c6680af2901539ceb11c949af8d9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Add `userLocationEnabled` prop to MapView to toggle showing the current user location on the map.

Requires location permission to be granted, otherwise silently ignored.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Enable prop in example app
- Grant location permission when prompted
- Verify blue dot appears at user location

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)