### PR TITLE
fix: smooth polyline animation

### DIFF
--- a/android/src/main/java/com/luggmaps/core/PolylineAnimator.kt
+++ b/android/src/main/java/com/luggmaps/core/PolylineAnimator.kt
@@ -2,13 +2,13 @@ package com.luggmaps.core
 
 import android.animation.ValueAnimator
 import android.graphics.Color
+import android.location.Location
 import android.view.animation.LinearInterpolator
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Polyline
 import com.google.android.gms.maps.model.StrokeStyle
 import com.google.android.gms.maps.model.StyleSpan
 import kotlin.math.floor
-import kotlin.math.max
 import kotlin.math.min
 
 class PolylineAnimator {
@@ -31,6 +31,8 @@ class PolylineAnimator {
 
   private var animator: ValueAnimator? = null
   private var animationProgress: Float = 0f
+  private var cumulativeDistances: FloatArray = floatArrayOf()
+  private var totalLength: Float = 0f
 
   fun update() {
     if (animated) return
@@ -50,8 +52,10 @@ class PolylineAnimator {
   private fun startAnimation() {
     if (animator != null) return
 
+    computeCumulativeDistances()
+
     animator = ValueAnimator.ofFloat(0f, 2.15f).apply {
-      duration = 3650 // ~1.75s per phase * 2 + pause
+      duration = 2150
       repeatCount = ValueAnimator.INFINITE
       interpolator = LinearInterpolator()
       addUpdateListener { animation ->
@@ -62,6 +66,58 @@ class PolylineAnimator {
     }
   }
 
+  private fun computeCumulativeDistances() {
+    if (coordinates.size < 2) {
+      cumulativeDistances = floatArrayOf(0f)
+      totalLength = 0f
+      return
+    }
+
+    val distances = FloatArray(coordinates.size)
+    distances[0] = 0f
+    var total = 0f
+
+    for (i in 1 until coordinates.size) {
+      val prev = coordinates[i - 1]
+      val curr = coordinates[i]
+      val results = FloatArray(1)
+      Location.distanceBetween(prev.latitude, prev.longitude, curr.latitude, curr.longitude, results)
+      total += results[0]
+      distances[i] = total
+    }
+
+    cumulativeDistances = distances
+    totalLength = total
+  }
+
+  private fun indexForDistance(distance: Float): Int {
+    for (i in 1 until cumulativeDistances.size) {
+      if (cumulativeDistances[i] >= distance) {
+        return i - 1
+      }
+    }
+    return (cumulativeDistances.size - 2).coerceAtLeast(0)
+  }
+
+  private fun coordinateAtDistance(distance: Float): LatLng {
+    if (distance <= 0f) return coordinates.first()
+    if (distance >= totalLength) return coordinates.last()
+
+    val idx = indexForDistance(distance)
+    val segStart = cumulativeDistances[idx]
+    val segEnd = cumulativeDistances[idx + 1]
+    val segLength = segEnd - segStart
+
+    val t = if (segLength > 0) (distance - segStart) / segLength else 0f
+    val c1 = coordinates[idx]
+    val c2 = coordinates[idx + 1]
+
+    return LatLng(
+      c1.latitude + (c2.latitude - c1.latitude) * t,
+      c1.longitude + (c2.longitude - c1.longitude) * t
+    )
+  }
+
   private fun stopAnimation() {
     animator?.cancel()
     animator = null
@@ -69,71 +125,55 @@ class PolylineAnimator {
 
   private fun updateAnimatedPolyline() {
     val poly = polyline ?: return
-    if (coordinates.size < 2) {
+    if (coordinates.size < 2 || totalLength <= 0f) {
       poly.points = coordinates
       return
     }
 
-    val segmentCount = coordinates.size - 1
     val progress = min(animationProgress, 2f)
 
-    val headPos: Float
-    val tailPos: Float
+    val headDist: Float
+    val tailDist: Float
 
     if (progress <= 1f) {
-      tailPos = 0f
-      headPos = progress * segmentCount
+      tailDist = 0f
+      headDist = progress * totalLength
     } else {
       val shrinkProgress = progress - 1f
-      tailPos = shrinkProgress * segmentCount
-      headPos = segmentCount.toFloat()
+      tailDist = shrinkProgress * totalLength
+      headDist = totalLength
     }
 
-    if (headPos <= tailPos || coordinates.isEmpty()) {
+    if (headDist <= tailDist) {
       poly.setSpans(emptyList())
       poly.points = listOf(coordinates.firstOrNull() ?: LatLng(0.0, 0.0))
       return
     }
 
-    val startIndex = floor(tailPos).toInt()
-    val endIndex = kotlin.math.ceil(headPos.toDouble()).toInt()
-    val visibleLength = headPos - tailPos
+    val visibleLength = headDist - tailDist
+    val startIndex = indexForDistance(tailDist)
+    val endIndex = indexForDistance(headDist)
 
     val points = mutableListOf<LatLng>()
     val spans = mutableListOf<StyleSpan>()
 
-    for (i in startIndex..minOf(endIndex, coordinates.size - 1)) {
-      var coord = coordinates[i]
+    points.add(coordinateAtDistance(tailDist))
 
-      // Interpolate tail
-      if (i == startIndex && tailPos > startIndex.toFloat() && i + 1 < coordinates.size) {
-        val t = tailPos - startIndex
-        val next = coordinates[i + 1]
-        coord = LatLng(
-          coord.latitude + (next.latitude - coord.latitude) * t,
-          coord.longitude + (next.longitude - coord.longitude) * t
-        )
-      }
+    for (i in (startIndex + 1)..endIndex) {
+      points.add(coordinates[i])
+    }
 
-      // Interpolate head
-      if (i == endIndex && headPos < endIndex.toFloat() && i > 0) {
-        val t = headPos - (endIndex - 1)
-        val prev = coordinates[i - 1]
-        coord = LatLng(
-          prev.latitude + (coordinates[i].latitude - prev.latitude) * t,
-          prev.longitude + (coordinates[i].longitude - prev.longitude) * t
-        )
-      }
+    val endCoord = coordinateAtDistance(headDist)
+    val lastAdded = points.lastOrNull()
+    if (lastAdded == null || endCoord.latitude != lastAdded.latitude || endCoord.longitude != lastAdded.longitude) {
+      points.add(endCoord)
+    }
 
-      points.add(coord)
-
-      if (i < endIndex && i < segmentCount) {
-        val segStartPos = max(i.toFloat(), tailPos)
-        val segEndPos = min((i + 1).toFloat(), headPos)
-        val gradientMid = ((segStartPos + segEndPos) / 2f - tailPos) / visibleLength
-        val color = colorAtGradientPosition(gradientMid)
-        spans.add(StyleSpan(StrokeStyle.colorBuilder(color).build()))
-      }
+    for (i in 0 until (points.size - 1)) {
+      val segMidDist = tailDist + visibleLength * (i + 0.5f) / (points.size - 1)
+      val gradientPos = (segMidDist - tailDist) / visibleLength
+      val color = colorAtGradientPosition(gradientPos)
+      spans.add(StyleSpan(StrokeStyle.colorBuilder(color).build()))
     }
 
     poly.points = points

--- a/example/shared/src/components/Map.tsx
+++ b/example/shared/src/components/Map.tsx
@@ -6,6 +6,7 @@ import { MarkerIcon } from './MarkerIcon';
 import { MarkerText } from './MarkerText';
 import { MarkerImage } from './MarkerImage';
 import type { MarkerData } from './index';
+import { Route } from './Route';
 
 interface MapProps extends MapViewProps {
   markers: MarkerData[];
@@ -89,6 +90,7 @@ export const Map = forwardRef<MapView, MapProps>(
             animated
           />
         )}
+        <Route />
         <Marker
           name="inline-marker"
           coordinate={{ latitude: 37.782, longitude: -122.425 }}

--- a/example/shared/src/components/Route.tsx
+++ b/example/shared/src/components/Route.tsx
@@ -1,0 +1,63 @@
+import { Polyline } from '@lugg/maps';
+
+const coordinates = [
+  { latitude: 37.785, longitude: -122.44 },
+  { latitude: 37.7848, longitude: -122.4395 },
+  { latitude: 37.7846, longitude: -122.439 },
+  { latitude: 37.7844, longitude: -122.4385 },
+  { latitude: 37.7842, longitude: -122.438 },
+  { latitude: 37.784, longitude: -122.4375 },
+  { latitude: 37.7838, longitude: -122.437 },
+  { latitude: 37.7836, longitude: -122.4365 },
+  { latitude: 37.7834, longitude: -122.436 },
+  { latitude: 37.7832, longitude: -122.4355 },
+  { latitude: 37.783, longitude: -122.435 },
+  { latitude: 37.7828, longitude: -122.4345 },
+  { latitude: 37.7826, longitude: -122.434 },
+  { latitude: 37.7824, longitude: -122.4335 },
+  { latitude: 37.7822, longitude: -122.433 },
+  { latitude: 37.782, longitude: -122.4325 },
+  { latitude: 37.7818, longitude: -122.432 },
+  { latitude: 37.7816, longitude: -122.4315 },
+  { latitude: 37.7814, longitude: -122.431 },
+  { latitude: 37.7812, longitude: -122.4305 },
+  { latitude: 37.781, longitude: -122.43 },
+  { latitude: 37.7808, longitude: -122.4295 },
+  { latitude: 37.7806, longitude: -122.429 },
+  { latitude: 37.7804, longitude: -122.4285 },
+  { latitude: 37.7802, longitude: -122.428 },
+  { latitude: 37.78, longitude: -122.4275 },
+  { latitude: 37.7798, longitude: -122.427 },
+  { latitude: 37.7796, longitude: -122.4265 },
+  { latitude: 37.7794, longitude: -122.426 },
+  { latitude: 37.7792, longitude: -122.4255 },
+  { latitude: 37.779, longitude: -122.425 },
+  { latitude: 37.7788, longitude: -122.4245 },
+  { latitude: 37.7786, longitude: -122.424 },
+  { latitude: 37.7784, longitude: -122.4235 },
+  { latitude: 37.7782, longitude: -122.423 },
+  { latitude: 37.778, longitude: -122.4225 },
+  { latitude: 37.7778, longitude: -122.422 },
+  { latitude: 37.7776, longitude: -122.4215 },
+  { latitude: 37.7774, longitude: -122.421 },
+  { latitude: 37.7772, longitude: -122.4205 },
+  { latitude: 37.777, longitude: -122.42 },
+  { latitude: 37.7772, longitude: -122.4195 },
+  { latitude: 37.7774, longitude: -122.419 },
+  { latitude: 37.7776, longitude: -122.4185 },
+  { latitude: 37.7778, longitude: -122.418 },
+  { latitude: 37.778, longitude: -122.4175 },
+  { latitude: 37.7782, longitude: -122.417 },
+  { latitude: 37.7784, longitude: -122.4165 },
+  { latitude: 37.7786, longitude: -122.416 },
+  { latitude: 37.7788, longitude: -122.4155 },
+];
+
+export const Route = () => (
+  <Polyline
+    strokeColors={['#FF5733', '#FFBD33']}
+    coordinates={coordinates}
+    strokeWidth={6}
+    animated
+  />
+);

--- a/ios/core/GMSPolylineAnimator.m
+++ b/ios/core/GMSPolylineAnimator.m
@@ -4,6 +4,8 @@
 @implementation GMSPolylineAnimator {
   CADisplayLink *_displayLink;
   CGFloat _animationProgress;
+  NSArray<NSNumber *> *_cumulativeDistances;
+  CGFloat _totalLength;
 }
 
 - (void)dealloc {
@@ -28,9 +30,26 @@
   if (_displayLink) {
     return;
   }
+  [self computeCumulativeDistances];
   _animationProgress = 0;
   _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(animationTick:)];
   [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+}
+
+- (void)computeCumulativeDistances {
+  NSMutableArray<NSNumber *> *distances = [NSMutableArray array];
+  CGFloat total = 0;
+  [distances addObject:@(0)];
+
+  for (NSUInteger i = 1; i < self.coordinates.count; i++) {
+    CLLocation *prev = self.coordinates[i - 1];
+    CLLocation *curr = self.coordinates[i];
+    total += [prev distanceFromLocation:curr];
+    [distances addObject:@(total)];
+  }
+
+  _cumulativeDistances = [distances copy];
+  _totalLength = total;
 }
 
 - (void)stopAnimation {
@@ -39,7 +58,7 @@
 }
 
 - (void)animationTick:(CADisplayLink *)displayLink {
-  CGFloat speed = displayLink.duration / 1.75;
+  CGFloat speed = displayLink.duration / 1.0;
   _animationProgress += speed;
 
   if (_animationProgress >= 2.15) {
@@ -71,63 +90,86 @@
   }
 }
 
+- (NSUInteger)indexForDistance:(CGFloat)distance {
+  for (NSUInteger i = 1; i < _cumulativeDistances.count; i++) {
+    if (_cumulativeDistances[i].doubleValue >= distance) {
+      return i - 1;
+    }
+  }
+  return _cumulativeDistances.count - 2;
+}
+
+- (CLLocationCoordinate2D)coordinateAtDistance:(CGFloat)distance {
+  if (distance <= 0) {
+    return self.coordinates.firstObject.coordinate;
+  }
+  if (distance >= _totalLength) {
+    return self.coordinates.lastObject.coordinate;
+  }
+
+  NSUInteger idx = [self indexForDistance:distance];
+  CGFloat segStart = _cumulativeDistances[idx].doubleValue;
+  CGFloat segEnd = _cumulativeDistances[idx + 1].doubleValue;
+  CGFloat segLength = segEnd - segStart;
+
+  CGFloat t = (segLength > 0) ? (distance - segStart) / segLength : 0;
+  CLLocationCoordinate2D c1 = self.coordinates[idx].coordinate;
+  CLLocationCoordinate2D c2 = self.coordinates[idx + 1].coordinate;
+
+  return CLLocationCoordinate2DMake(c1.latitude + (c2.latitude - c1.latitude) * t,
+                                    c1.longitude + (c2.longitude - c1.longitude) * t);
+}
+
 - (void)updateAnimatedPolyline {
-  if (!_polyline || self.coordinates.count < 2) {
+  if (!_polyline || self.coordinates.count < 2 || _totalLength <= 0) {
     return;
   }
 
-  NSUInteger segmentCount = self.coordinates.count - 1;
   CGFloat progress = MIN(_animationProgress, 2.0);
-  CGFloat headPos, tailPos;
+  CGFloat headDist, tailDist;
 
   if (progress <= 1.0) {
-    tailPos = 0;
-    headPos = progress * segmentCount;
+    tailDist = 0;
+    headDist = progress * _totalLength;
   } else {
     CGFloat shrinkProgress = progress - 1.0;
-    tailPos = shrinkProgress * segmentCount;
-    headPos = segmentCount;
+    tailDist = shrinkProgress * _totalLength;
+    headDist = _totalLength;
   }
 
-  if (headPos <= tailPos) {
+  if (headDist <= tailDist) {
     _polyline.path = [GMSMutablePath path];
     return;
   }
 
-  NSUInteger startIndex = (NSUInteger)floor(tailPos);
-  NSUInteger endIndex = (NSUInteger)ceil(headPos);
-  CGFloat visibleLength = headPos - tailPos;
+  CGFloat visibleLength = headDist - tailDist;
+  NSUInteger startIndex = [self indexForDistance:tailDist];
+  NSUInteger endIndex = [self indexForDistance:headDist];
 
   GMSMutablePath *path = [GMSMutablePath path];
   NSMutableArray<GMSStyleSpan *> *spans = [NSMutableArray array];
 
-  for (NSUInteger i = startIndex; i <= endIndex && i < self.coordinates.count; i++) {
-    CLLocationCoordinate2D coord = self.coordinates[i].coordinate;
+  CLLocationCoordinate2D startCoord = [self coordinateAtDistance:tailDist];
+  [path addCoordinate:startCoord];
 
-    if (i == startIndex && tailPos > (CGFloat)startIndex) {
-      CGFloat t = tailPos - (CGFloat)startIndex;
-      CLLocationCoordinate2D nextCoord = self.coordinates[i + 1].coordinate;
-      coord.latitude = coord.latitude + (nextCoord.latitude - coord.latitude) * t;
-      coord.longitude = coord.longitude + (nextCoord.longitude - coord.longitude) * t;
-    }
+  for (NSUInteger i = startIndex + 1; i <= endIndex; i++) {
+    [path addCoordinate:self.coordinates[i].coordinate];
+  }
 
-    if (i == endIndex && headPos < (CGFloat)endIndex && i > 0) {
-      CGFloat t = headPos - (CGFloat)(endIndex - 1);
-      CLLocationCoordinate2D prevCoord = self.coordinates[i - 1].coordinate;
-      coord.latitude = prevCoord.latitude + (coord.latitude - prevCoord.latitude) * t;
-      coord.longitude = prevCoord.longitude + (coord.longitude - prevCoord.longitude) * t;
-    }
+  CLLocationCoordinate2D endCoord = [self coordinateAtDistance:headDist];
+  CLLocationCoordinate2D lastAdded =
+      (endIndex < self.coordinates.count) ? self.coordinates[endIndex].coordinate : endCoord;
+  if (endCoord.latitude != lastAdded.latitude || endCoord.longitude != lastAdded.longitude) {
+    [path addCoordinate:endCoord];
+  }
 
-    [path addCoordinate:coord];
-
-    if (i < endIndex && i < segmentCount) {
-      CGFloat segStartPos = MAX((CGFloat)i, tailPos);
-      CGFloat segEndPos = MIN((CGFloat)(i + 1), headPos);
-      CGFloat gradientMid = ((segStartPos + segEndPos) / 2.0 - tailPos) / visibleLength;
-      UIColor *color = [self colorAtGradientPosition:gradientMid];
-      GMSStrokeStyle *style = [GMSStrokeStyle solidColor:color];
-      [spans addObject:[GMSStyleSpan spanWithStyle:style]];
-    }
+  NSUInteger pathCount = path.count;
+  for (NSUInteger i = 0; i < pathCount - 1; i++) {
+    CGFloat segMidDist = tailDist + visibleLength * ((CGFloat)i + 0.5) / (CGFloat)(pathCount - 1);
+    CGFloat gradientPos = (segMidDist - tailDist) / visibleLength;
+    UIColor *color = [self colorAtGradientPosition:gradientPos];
+    GMSStrokeStyle *style = [GMSStrokeStyle solidColor:color];
+    [spans addObject:[GMSStyleSpan spanWithStyle:style]];
   }
 
   _polyline.path = path;

--- a/ios/core/MKPolylineAnimator.m
+++ b/ios/core/MKPolylineAnimator.m
@@ -4,7 +4,9 @@
 @implementation MKPolylineAnimator {
   MKPolyline *_polyline;
   CADisplayLink *_displayLink;
-  CGFloat _animationProgress; // 0→1 grow, 1→2 shrink
+  CGFloat _animationProgress;
+  NSArray<NSNumber *> *_cumulativeDistances;
+  CGFloat _totalLength;
 }
 
 - (id)initWithPolyline:(MKPolyline *)polyline {
@@ -38,9 +40,26 @@
   if (_displayLink) {
     return;
   }
+  [self computeCumulativeDistances];
   _animationProgress = 0;
   _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(animationTick:)];
   [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+}
+
+- (void)computeCumulativeDistances {
+  NSMutableArray<NSNumber *> *distances = [NSMutableArray array];
+  CGFloat total = 0;
+  [distances addObject:@(0)];
+
+  for (NSUInteger i = 1; i < _polyline.pointCount; i++) {
+    MKMapPoint p1 = _polyline.points[i - 1];
+    MKMapPoint p2 = _polyline.points[i];
+    total += MKMetersBetweenMapPoints(p1, p2);
+    [distances addObject:@(total)];
+  }
+
+  _cumulativeDistances = [distances copy];
+  _totalLength = total;
 }
 
 - (void)stopAnimation {
@@ -48,13 +67,20 @@
   _displayLink = nil;
 }
 
+- (NSUInteger)indexForDistance:(CGFloat)distance {
+  for (NSUInteger i = 1; i < _cumulativeDistances.count; i++) {
+    if (_cumulativeDistances[i].doubleValue >= distance) {
+      return i - 1;
+    }
+  }
+  return _cumulativeDistances.count - 2;
+}
+
 - (void)animationTick:(CADisplayLink *)displayLink {
-  // ~1.75s per phase (grow or shrink), matching JS duration
-  CGFloat speed = displayLink.duration / 1.75;
+  CGFloat speed = displayLink.duration / 1.0;
   _animationProgress += speed;
 
-  // 0→1 grow, 1→2 shrink, then reset with small pause
-  if (_animationProgress >= 2.15) { // 2.0 + 0.15 pause (~300ms at this speed)
+  if (_animationProgress >= 2.15) {
     _animationProgress = 0;
   }
 
@@ -135,62 +161,64 @@
   }
 
   // Snake animation: grow from start, then shrink from start
-  if (_animated && _polyline.pointCount > 1) {
+  if (_animated && _polyline.pointCount > 1 && _totalLength > 0) {
     CGFloat progress = MIN(_animationProgress, 2.0);
-    CGFloat headPos, tailPos;
+    CGFloat headDist, tailDist;
 
     if (progress <= 1.0) {
-      // Phase 1: grow from start to end
-      tailPos = 0;
-      headPos = progress * segmentCount;
+      tailDist = 0;
+      headDist = progress * _totalLength;
     } else {
-      // Phase 2: shrink from start
       CGFloat shrinkProgress = progress - 1.0;
-      tailPos = shrinkProgress * segmentCount;
-      headPos = segmentCount;
+      tailDist = shrinkProgress * _totalLength;
+      headDist = _totalLength;
     }
 
-    if (headPos <= tailPos) {
+    if (headDist <= tailDist) {
       return;
     }
 
-    NSUInteger startIndex = (NSUInteger)floor(tailPos);
-    NSUInteger endIndex = (NSUInteger)ceil(headPos);
-    CGFloat visibleLength = headPos - tailPos;
+    CGFloat visibleLength = headDist - tailDist;
+    NSUInteger startIndex = [self indexForDistance:tailDist];
+    NSUInteger endIndex = [self indexForDistance:headDist];
 
-    for (NSUInteger i = startIndex; i < endIndex && i < segmentCount; i++) {
+    for (NSUInteger i = startIndex; i <= endIndex && i < segmentCount; i++) {
+      CGFloat segStartDist = _cumulativeDistances[i].doubleValue;
+      CGFloat segEndDist = _cumulativeDistances[i + 1].doubleValue;
+
+      if (segEndDist <= tailDist || segStartDist >= headDist) {
+        continue;
+      }
+
       CGPoint segStart = [self pointForMapPoint:_polyline.points[i]];
       CGPoint segEnd = [self pointForMapPoint:_polyline.points[i + 1]];
 
       CGPoint drawStart = segStart;
       CGPoint drawEnd = segEnd;
-      CGFloat segStartPos = (CGFloat)i;
-      CGFloat segEndPos = (CGFloat)(i + 1);
+      CGFloat drawStartDist = segStartDist;
+      CGFloat drawEndDist = segEndDist;
+      CGFloat segLength = segEndDist - segStartDist;
 
-      // Interpolate tail (partial segment at start)
-      if (segStartPos < tailPos) {
-        CGFloat t = tailPos - segStartPos;
+      if (segStartDist < tailDist && segLength > 0) {
+        CGFloat t = (tailDist - segStartDist) / segLength;
         drawStart.x = segStart.x + (segEnd.x - segStart.x) * t;
         drawStart.y = segStart.y + (segEnd.y - segStart.y) * t;
-        segStartPos = tailPos;
+        drawStartDist = tailDist;
       }
 
-      // Interpolate head (partial segment at end)
-      if (segEndPos > headPos) {
-        CGFloat t = headPos - (CGFloat)i;
+      if (segEndDist > headDist && segLength > 0) {
+        CGFloat t = (headDist - segStartDist) / segLength;
         drawEnd.x = segStart.x + (segEnd.x - segStart.x) * t;
         drawEnd.y = segStart.y + (segEnd.y - segStart.y) * t;
-        segEndPos = headPos;
+        drawEndDist = headDist;
       }
 
-      // Calculate gradient position (0-1) within visible portion
-      CGFloat gradientStart = (segStartPos - tailPos) / visibleLength;
-      CGFloat gradientEnd = (segEndPos - tailPos) / visibleLength;
+      CGFloat gradientStart = (drawStartDist - tailDist) / visibleLength;
+      CGFloat gradientEnd = (drawEndDist - tailDist) / visibleLength;
 
       UIColor *startColor = [self colorAtGradientPosition:gradientStart];
       UIColor *endColor = [self colorAtGradientPosition:gradientEnd];
 
-      // Draw gradient line segment
       CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
       NSArray *colors = @[(__bridge id)startColor.CGColor, (__bridge id)endColor.CGColor];
       CGGradientRef gradient = CGGradientCreateWithColors(colorSpace, (__bridge CFArrayRef)colors, NULL);


### PR DESCRIPTION
## Summary
Use distance-based animation instead of segment-index for consistent speed regardless of coordinate density.

## Type of Change
- [x] Bug fix

## Test Plan
Tested with Route.tsx example containing 50 coordinates - animation now moves at constant visual speed.

## Checklist
- [x] iOS
- [x] Android