### PR TITLE
fix: only set groundAnchor for custom markers on iOS Google Maps

### DIFF
--- a/example/shared/src/Home.tsx
+++ b/example/shared/src/Home.tsx
@@ -61,7 +61,9 @@ export function Home() {
     sheetRef.current?.present();
   }, []);
 
-  const addRandomMarker = () => {
+  const addMarker = () => {
+    if (!cameraPosition) return;
+
     const type = randomFrom(MARKER_TYPES);
     const id = Date.now().toString();
 
@@ -70,10 +72,7 @@ export function Home() {
       {
         id,
         name: `marker-${id}`,
-        coordinate: {
-          latitude: 37.77 + Math.random() * 0.03,
-          longitude: -122.45 + Math.random() * 0.05,
-        },
+        coordinate: cameraPosition.coordinate,
         type,
         anchor: { x: 0.5, y: type === 'icon' ? 1 : 0.5 },
         text: randomLetter(),
@@ -141,7 +140,7 @@ export function Home() {
           </Text>
         )}
         <View style={styles.sheetContent}>
-          <Button title="Add Marker" onPress={addRandomMarker} />
+          <Button title="Add Marker" onPress={addMarker} />
           <Button
             title={`Remove Marker (${markers.length})`}
             onPress={removeRandomMarker}

--- a/example/shared/src/components/Map.tsx
+++ b/example/shared/src/components/Map.tsx
@@ -62,15 +62,15 @@ const renderMarker = (marker: MarkerData) => {
           coordinate={coordinate}
           title={title}
           description={description}
-          anchor={anchor}
         />
       );
   }
 };
 
 export const Map = forwardRef<MapView, MapProps>(
-  ({ markers, ...props }, ref) => {
+  ({ markers, padding, ...props }, ref) => {
     const polylineCoordinates = markers.map((m) => m.coordinate);
+    const bottomOffset = padding?.bottom ?? 0;
 
     return (
       <MapView
@@ -79,6 +79,7 @@ export const Map = forwardRef<MapView, MapProps>(
         mapId="6939261d95ee48fd57332474"
         initialCoordinate={{ latitude: 37.78, longitude: -122.43 }}
         initialZoom={14}
+        padding={padding}
         {...props}
       >
         {markers.map(renderMarker)}
@@ -89,7 +90,12 @@ export const Map = forwardRef<MapView, MapProps>(
         >
           <View style={styles.customMarker} />
         </Marker>
-        <View style={styles.centerPin} />
+        <View
+          style={[
+            styles.centerPin,
+            { transform: [{ translateY: -bottomOffset / 2 }] },
+          ]}
+        />
       </MapView>
     );
   }

--- a/ios/LuggGoogleMapView.mm
+++ b/ios/LuggGoogleMapView.mm
@@ -242,14 +242,14 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
   marker.position = markerView.coordinate;
   marker.title = markerView.title;
   marker.snippet = markerView.markerDescription;
-  marker.groundAnchor = markerView.anchor;
-
   if (markerView.hasCustomView) {
     UIView *iconView = markerView.iconView;
     [iconView removeFromSuperview];
     marker.iconView = iconView;
+    marker.groundAnchor = markerView.anchor;
   } else {
     marker.iconView = nil;
+    marker.groundAnchor = CGPointMake(0.5, 1);
   }
 }
 
@@ -280,9 +280,9 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
 
   if (markerView.hasCustomView) {
     marker.iconView = iconView;
+    marker.groundAnchor = markerView.anchor;
   }
 
-  marker.groundAnchor = markerView.anchor;
   marker.map = _mapView;
 
   markerView.marker = marker;


### PR DESCRIPTION
## Summary
Fix default marker positioning on iOS Google Maps by only setting `groundAnchor` for custom markers, letting the system handle the default marker anchor.

## Type of Change
- [x] Bug fix

## Test Plan
- Tested on iOS with Google Maps provider
- Verified default markers position correctly
- Verified custom markers still use custom anchor

## Checklist
- [x] iOS
- [ ] Android
- [ ] Web