### PR TITLE
feat(polyline): add zIndex prop

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
+++ b/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
@@ -338,6 +338,7 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
     }
 
     polylineView.polyline?.width = polylineView.strokeWidth.dpToPx()
+    polylineView.polyline?.zIndex = polylineView.zIndex
 
     polylineAnimators[polylineView]?.apply {
       coordinates = polylineView.coordinates
@@ -360,6 +361,7 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
 
     val options = PolylineOptions()
       .width(polylineView.strokeWidth.dpToPx())
+      .zIndex(polylineView.zIndex)
 
     val polyline = map.addPolyline(options)
     polylineView.polyline = polyline

--- a/android/src/main/java/com/luggmaps/LuggPolylineView.kt
+++ b/android/src/main/java/com/luggmaps/LuggPolylineView.kt
@@ -25,6 +25,9 @@ class LuggPolylineView(context: Context) : ReactViewGroup(context) {
   var animated: Boolean = false
     private set
 
+  var zIndex: Float = 0f
+    private set
+
   var cachedSpans: List<StyleSpan>? = null
     private set
 
@@ -53,6 +56,10 @@ class LuggPolylineView(context: Context) : ReactViewGroup(context) {
 
   fun setAnimated(value: Boolean) {
     animated = value
+  }
+
+  fun setZIndex(value: Float) {
+    zIndex = value
   }
 
   fun getOrCreateSpans(): List<StyleSpan> {

--- a/android/src/main/java/com/luggmaps/LuggPolylineViewManager.kt
+++ b/android/src/main/java/com/luggmaps/LuggPolylineViewManager.kt
@@ -65,6 +65,12 @@ class LuggPolylineViewManager :
     view.setAnimated(value)
   }
 
+  @ReactProp(name = "zIndex", defaultFloat = 0f)
+  override fun setZIndex(view: LuggPolylineView, value: Float) {
+    super.setZIndex(view, value)
+    view.setZIndex(value)
+  }
+
   companion object {
     const val NAME = "LuggPolylineView"
   }

--- a/example/shared/src/components/Route.tsx
+++ b/example/shared/src/components/Route.tsx
@@ -72,11 +72,18 @@ export const Route = ({ markerCoordinates }: RouteProps) => {
   if (smoothed.length < 2) return null;
 
   return (
-    <Polyline
-      strokeColors={['#B321E0', '#3744FF']}
-      coordinates={smoothed}
-      strokeWidth={6}
-      animated
-    />
+    <>
+      <Polyline
+        strokeColors={['#B0B0B0']}
+        coordinates={smoothed}
+        strokeWidth={6}
+      />
+      <Polyline
+        strokeColors={['#B321E0', '#3744FF']}
+        coordinates={smoothed}
+        strokeWidth={6}
+        animated
+      />
+    </>
   );
 };

--- a/ios/LuggAppleMapView.mm
+++ b/ios/LuggAppleMapView.mm
@@ -302,7 +302,7 @@ using namespace luggmaps::events;
   free(coords);
 
   polylineView.polyline = polyline;
-  [_mapView addOverlay:polyline];
+  [self insertOverlay:polyline withZIndex:polylineView.zIndex];
 }
 
 - (void)syncPolylineView:(LuggPolylineView *)polylineView {
@@ -341,7 +341,7 @@ using namespace luggmaps::events;
   // If we have an existing renderer, update it in place
   if (renderer && oldPolyline) {
     [_mapView removeOverlay:oldPolyline];
-    [_mapView addOverlay:newPolyline];
+    [self insertOverlay:newPolyline withZIndex:polylineView.zIndex];
     [renderer updatePolyline:newPolyline];
     renderer.lineWidth = polylineView.strokeWidth;
     renderer.strokeColor = polylineView.strokeColors.firstObject;
@@ -355,7 +355,28 @@ using namespace luggmaps::events;
   if (oldPolyline) {
     [_mapView removeOverlay:oldPolyline];
   }
-  [_mapView addOverlay:newPolyline];
+  [self insertOverlay:newPolyline withZIndex:polylineView.zIndex];
+}
+
+- (void)insertOverlay:(id<MKOverlay>)overlay withZIndex:(NSInteger)zIndex {
+  if (zIndex == 0) {
+    [_mapView addOverlay:overlay];
+    return;
+  }
+
+  NSArray<id<MKOverlay>> *overlays = _mapView.overlays;
+  NSInteger insertIndex = overlays.count;
+
+  for (NSInteger i = 0; i < overlays.count; i++) {
+    LuggPolylineView *existingPolylineView =
+        [self findPolylineViewForOverlay:overlays[i]];
+    if (existingPolylineView && existingPolylineView.zIndex > zIndex) {
+      insertIndex = i;
+      break;
+    }
+  }
+
+  [_mapView insertOverlay:overlay atIndex:insertIndex];
 }
 
 - (LuggPolylineView *)findPolylineViewForOverlay:(id<MKOverlay>)overlay {

--- a/ios/LuggGoogleMapView.mm
+++ b/ios/LuggGoogleMapView.mm
@@ -307,6 +307,7 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
 
   GMSPolyline *polyline = (GMSPolyline *)polylineView.polyline;
   polyline.strokeWidth = polylineView.strokeWidth;
+  polyline.zIndex = (int)polylineView.zIndex;
 
   GMSPolylineAnimator *animator =
       [_polylineAnimators objectForKey:polylineView];
@@ -336,6 +337,7 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
 
   GMSPolyline *polyline = [GMSPolyline polylineWithPath:[GMSMutablePath path]];
   polyline.strokeWidth = polylineView.strokeWidth;
+  polyline.zIndex = (int)polylineView.zIndex;
   polyline.map = _mapView;
   polylineView.polyline = polyline;
 

--- a/ios/LuggPolylineView.h
+++ b/ios/LuggPolylineView.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSArray<UIColor *> *strokeColors;
 @property(nonatomic, readonly) BOOL animated;
 @property(nonatomic, readonly) CGFloat strokeWidth;
+@property(nonatomic, readonly) NSInteger zIndex;
 @property(nonatomic, weak, nullable) id<LuggPolylineViewDelegate> delegate;
 @property(nonatomic, strong, nullable) NSObject *polyline;
 @property(nonatomic, weak, nullable) NSObject *renderer;

--- a/ios/LuggPolylineView.mm
+++ b/ios/LuggPolylineView.mm
@@ -18,6 +18,7 @@ using namespace facebook::react;
   NSArray<UIColor *> *_strokeColors;
   BOOL _animated;
   CGFloat _strokeWidth;
+  NSInteger _zIndex;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider {
@@ -71,8 +72,8 @@ using namespace facebook::react;
   }
 
   _animated = newViewProps.animated;
-
   _strokeWidth = newViewProps.strokeWidth > 0 ? newViewProps.strokeWidth : 1.0;
+  _zIndex = newViewProps.zIndex.value_or(0);
 }
 
 - (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask {
@@ -99,6 +100,10 @@ using namespace facebook::react;
 
 - (CGFloat)strokeWidth {
   return _strokeWidth;
+}
+
+- (NSInteger)zIndex {
+  return _zIndex;
 }
 
 - (void)prepareForRecycle {

--- a/src/components/Polyline.tsx
+++ b/src/components/Polyline.tsx
@@ -21,6 +21,10 @@ export interface PolylineProps {
    * Animate the polyline with a snake effect
    */
   animated?: boolean;
+  /**
+   * Z-index for layering polylines
+   */
+  zIndex?: number;
 }
 
 export class Polyline extends React.Component<PolylineProps> {
@@ -30,11 +34,12 @@ export class Polyline extends React.Component<PolylineProps> {
       strokeColors,
       strokeWidth,
       animated = false,
+      zIndex,
     } = this.props;
 
     return (
       <LuggPolylineViewNativeComponent
-        style={styles.polyline}
+        style={[{ zIndex }, styles.polyline]}
         coordinates={coordinates}
         strokeColors={strokeColors}
         strokeWidth={strokeWidth}

--- a/src/components/Polyline.web.tsx
+++ b/src/components/Polyline.web.tsx
@@ -46,7 +46,9 @@ function PolylineImpl({
   strokeColors,
   strokeWidth = 1,
   animated,
+  zIndex,
 }: PolylineProps) {
+  const resolvedZIndex = zIndex ?? (animated ? 1 : 0);
   const map = useMap();
   const polylinesRef = useRef<google.maps.Polyline[]>([]);
   const animationRef = useRef<number>(0);
@@ -62,13 +64,13 @@ function PolylineImpl({
   const hasGradient = colors.length > 1;
 
   // Refs for animation loop access
-  const propsRef = useRef({ map, colors, strokeWidth, hasGradient });
+  const propsRef = useRef({ map, colors, strokeWidth, hasGradient, zIndex: resolvedZIndex });
   const [mapReady, setMapReady] = useState(!!map);
 
   useEffect(() => {
-    propsRef.current = { map, colors, strokeWidth, hasGradient };
+    propsRef.current = { map, colors, strokeWidth, hasGradient, zIndex: resolvedZIndex };
     if (map && !mapReady) setMapReady(true);
-  }, [map, colors, strokeWidth, hasGradient, mapReady]);
+  }, [map, colors, strokeWidth, hasGradient, resolvedZIndex, mapReady]);
 
   const updatePath = useCallback((path: google.maps.LatLngLiteral[]) => {
     const {
@@ -76,6 +78,7 @@ function PolylineImpl({
       colors: currentColors,
       strokeWidth: currentStrokeWidth,
       hasGradient: currentHasGradient,
+      zIndex: currentZIndex,
     } = propsRef.current;
     if (!currentMap || path.length < 2) return;
 
@@ -100,6 +103,7 @@ function PolylineImpl({
             strokeColor: color,
             strokeWeight: currentStrokeWidth,
             strokeOpacity: 1,
+            zIndex: currentZIndex,
             map: currentMap,
           })
         );


### PR DESCRIPTION
## Summary
Add `zIndex` prop to `Polyline` component for controlling overlay layering order.

## Type of Change
- [x] New feature

## Test Plan
- Tested on iOS (Apple Maps and Google Maps)
- Tested on Android (Google Maps)
- Tested on Web

## Checklist
- [x] iOS
- [x] Android
- [x] Web