### PR TITLE
fix(android): marker iconView not updating on resize

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
+++ b/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
@@ -241,9 +241,12 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
     }
 
     if (markerView.hasCustomView) {
+      if (markerView.isPendingUpdate) return
+      markerView.isPendingUpdate = true
       markerView.marker?.remove()
       markerView.marker = null
       markerView.post {
+        markerView.isPendingUpdate = false
         addMarkerViewToMap(markerView)
       }
     } else {

--- a/android/src/main/java/com/luggmaps/LuggMarkerView.kt
+++ b/android/src/main/java/com/luggmaps/LuggMarkerView.kt
@@ -39,6 +39,8 @@ class LuggMarkerView(context: Context) : ReactViewGroup(context) {
   var didLayout: Boolean = false
     private set
 
+  var isPendingUpdate: Boolean = false
+
   val hasCustomView: Boolean
     get() = iconView.childCount > 0
 


### PR DESCRIPTION
## Summary
Fix marker custom view (iconView) not updating bounds when resized on Android.

## Problem
Google Maps SDK caches the iconView dimensions and doesn't re-measure when children change size.

## Solution
- Create a new wrapper view with fixed dimensions each time the marker layout changes
- Post the marker recreation to allow React Native to finish layout first
- Remove iconView from existing parent before adding to new wrapper

## Type of Change
- [x] Bug fix

## Test Plan
- Tested markers with dynamic content that changes size
- Verified markers resize correctly without clipping

## Checklist
- [x] iOS
- [x] Android
- [ ] Web