### PR TITLE
fix: pause polyline animation during map drag

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
+++ b/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
@@ -173,6 +173,9 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
 
   override fun onCameraMoveStarted(reason: Int) {
     isDragging = reason == GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE
+    if (isDragging) {
+      polylineAnimators.values.forEach { it.pause() }
+    }
   }
 
   override fun onCameraMove() {
@@ -185,6 +188,9 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
     val map = googleMap ?: return
     val position = map.cameraPosition
     eventDelegate?.onCameraIdle(this, position.target.latitude, position.target.longitude, position.zoom, isDragging)
+    if (isDragging) {
+      polylineAnimators.values.forEach { it.resume() }
+    }
     isDragging = false
   }
 

--- a/android/src/main/java/com/luggmaps/core/PolylineAnimator.kt
+++ b/android/src/main/java/com/luggmaps/core/PolylineAnimator.kt
@@ -143,6 +143,14 @@ class PolylineAnimator {
     animator = null
   }
 
+  fun pause() {
+    animator?.pause()
+  }
+
+  fun resume() {
+    animator?.resume()
+  }
+
   private fun updateAnimatedPolyline() {
     val poly = polyline ?: return
     if (coordinates.size < 2 || totalLength <= 0f) {

--- a/ios/LuggAppleMapView.mm
+++ b/ios/LuggAppleMapView.mm
@@ -433,6 +433,14 @@ using namespace luggmaps::events;
 
 - (void)mapView:(MKMapView *)mapView regionWillChangeAnimated:(BOOL)animated {
   _isDragging = [self isUserInteracting:mapView];
+  if (_isDragging) {
+    for (UIView *subview in self.subviews) {
+      if ([subview isKindOfClass:[LuggPolylineView class]]) {
+        MKPolylineAnimator *renderer = (MKPolylineAnimator *)((LuggPolylineView *)subview).renderer;
+        [renderer pause];
+      }
+    }
+  }
 }
 
 - (BOOL)isUserInteracting:(MKMapView *)mapView {
@@ -456,6 +464,14 @@ using namespace luggmaps::events;
 - (void)mapView:(MKMapView *)mapView regionDidChangeAnimated:(BOOL)animated {
   BOOL wasDragging = _isDragging;
   _isDragging = NO;
+  if (wasDragging) {
+    for (UIView *subview in self.subviews) {
+      if ([subview isKindOfClass:[LuggPolylineView class]]) {
+        MKPolylineAnimator *renderer = (MKPolylineAnimator *)((LuggPolylineView *)subview).renderer;
+        [renderer resume];
+      }
+    }
+  }
   CameraIdleEvent{mapView.centerCoordinate.latitude,
                   mapView.centerCoordinate.longitude, mapView.zoomLevel,
                   static_cast<bool>(wasDragging)}

--- a/ios/LuggGoogleMapView.mm
+++ b/ios/LuggGoogleMapView.mm
@@ -189,6 +189,11 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
 
 - (void)mapView:(GMSMapView *)mapView willMove:(BOOL)gesture {
   _isDragging = gesture;
+  if (_isDragging) {
+    for (GMSPolylineAnimator *animator in _polylineAnimators.objectEnumerator) {
+      [animator pause];
+    }
+  }
 }
 
 - (void)mapView:(GMSMapView *)mapView
@@ -202,6 +207,11 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
     idleAtCameraPosition:(GMSCameraPosition *)position {
   BOOL wasDragging = _isDragging;
   _isDragging = NO;
+  if (wasDragging) {
+    for (GMSPolylineAnimator *animator in _polylineAnimators.objectEnumerator) {
+      [animator resume];
+    }
+  }
   CameraIdleEvent{position.target.latitude, position.target.longitude,
                   position.zoom, static_cast<bool>(wasDragging)}
       .emit<LuggGoogleMapViewEventEmitter>(_eventEmitter);

--- a/ios/core/GMSPolylineAnimator.h
+++ b/ios/core/GMSPolylineAnimator.h
@@ -7,5 +7,7 @@
 @property(nonatomic, assign) BOOL animated;
 
 - (void)update;
+- (void)pause;
+- (void)resume;
 
 @end

--- a/ios/core/GMSPolylineAnimator.m
+++ b/ios/core/GMSPolylineAnimator.m
@@ -92,6 +92,14 @@
   _displayLinkProxy = nil;
 }
 
+- (void)pause {
+  _displayLink.paused = YES;
+}
+
+- (void)resume {
+  _displayLink.paused = NO;
+}
+
 - (void)animationTick:(CADisplayLink *)displayLink {
   CGFloat speed = displayLink.duration / 1.0;
   _animationProgress += speed;

--- a/ios/core/MKPolylineAnimator.h
+++ b/ios/core/MKPolylineAnimator.h
@@ -8,5 +8,7 @@
 @property(nonatomic, assign) BOOL animated;
 
 - (void)updatePolyline:(MKPolyline *)polyline;
+- (void)pause;
+- (void)resume;
 
 @end

--- a/ios/core/MKPolylineAnimator.m
+++ b/ios/core/MKPolylineAnimator.m
@@ -101,6 +101,14 @@
   _displayLinkProxy = nil;
 }
 
+- (void)pause {
+  _displayLink.paused = YES;
+}
+
+- (void)resume {
+  _displayLink.paused = NO;
+}
+
 - (NSUInteger)indexForDistance:(CGFloat)distance {
   NSUInteger left = 0;
   NSUInteger right = _cumulativeDistances.count - 1;


### PR DESCRIPTION
## Summary

Pauses polyline animations during map drag gestures to prevent animation jank.

## Type of Change

- [x] Bug fix

## Test Plan

Tested on iOS (Apple Maps & Google Maps) and Android - animations pause smoothly during drag and resume after.

## Checklist

- [x] iOS
- [x] Android
- [ ] Web