### PR TITLE
fix(web): pause polyline animation during map drag

### DIFF
--- a/ios/LuggAppleMapView.mm
+++ b/ios/LuggAppleMapView.mm
@@ -436,7 +436,8 @@ using namespace luggmaps::events;
   if (_isDragging) {
     for (UIView *subview in self.subviews) {
       if ([subview isKindOfClass:[LuggPolylineView class]]) {
-        MKPolylineAnimator *renderer = (MKPolylineAnimator *)((LuggPolylineView *)subview).renderer;
+        MKPolylineAnimator *renderer =
+            (MKPolylineAnimator *)((LuggPolylineView *)subview).renderer;
         [renderer pause];
       }
     }
@@ -467,7 +468,8 @@ using namespace luggmaps::events;
   if (wasDragging) {
     for (UIView *subview in self.subviews) {
       if ([subview isKindOfClass:[LuggPolylineView class]]) {
-        MKPolylineAnimator *renderer = (MKPolylineAnimator *)((LuggPolylineView *)subview).renderer;
+        MKPolylineAnimator *renderer =
+            (MKPolylineAnimator *)((LuggPolylineView *)subview).renderer;
         [renderer resume];
       }
     }

--- a/src/MapProvider.web.tsx
+++ b/src/MapProvider.web.tsx
@@ -2,9 +2,12 @@ import { createContext, useContext } from 'react';
 import { APIProvider } from '@vis.gl/react-google-maps';
 import type { MapProviderProps } from './MapProvider.types';
 
-export const MapIdContext = createContext<string | null>(null);
+export const MapContext = createContext<{
+  map: google.maps.Map | null;
+  isDragging: boolean;
+}>({ map: null, isDragging: false });
 
-export const useMapId = () => useContext(MapIdContext);
+export const useMapContext = () => useContext(MapContext);
 
 export function MapProvider({ apiKey = '', children }: MapProviderProps) {
   return <APIProvider apiKey={apiKey}>{children}</APIProvider>;

--- a/src/MapView.web.tsx
+++ b/src/MapView.web.tsx
@@ -17,7 +17,7 @@ import {
   type MapEvent,
 } from '@vis.gl/react-google-maps';
 import { Marker } from './components/Marker.web';
-import { MapIdContext } from './MapProvider.web';
+import { MapContext } from './MapProvider.web';
 
 import type {
   MapViewProps,
@@ -119,7 +119,7 @@ export const MapView = forwardRef<MapViewRef, MapViewProps>(function MapView(
   const map = useMap(id);
   const containerRef = useRef<View>(null);
   const readyFired = useRef(false);
-  const isDragging = useRef(false);
+  const [isDragging, setIsDragging] = useState(false);
   const wasGesture = useRef(false);
   const prevPadding = useRef(padding);
 
@@ -161,18 +161,18 @@ export const MapView = forwardRef<MapViewRef, MapViewProps>(function MapView(
   useImperativeHandle(
     ref,
     () => ({
-      moveCamera(coordinate: Coordinate, options: MoveCameraOptions) {
+      moveCamera(coordinate: Coordinate, options?: MoveCameraOptions) {
         if (!map) return;
 
-        const { zoom, duration = -1 } = options;
-        const targetZoom = zoom ?? map.getZoom() ?? initialZoom;
+        const { zoom = 0, duration = -1 } = options ?? {};
+        const targetZoom = zoom || map.getZoom() || initialZoom;
         const center = offsetCenter(coordinate, targetZoom, undefined, false);
 
         if (duration === 0) {
           map.moveCamera({ center, zoom: targetZoom });
         } else {
           const currentZoom = map.getZoom();
-          const zoomChanged = zoom !== undefined && zoom !== currentZoom;
+          const zoomChanged = zoom !== 0 && zoom !== currentZoom;
 
           if (zoomChanged) {
             map.setZoom(zoom);
@@ -251,12 +251,12 @@ export const MapView = forwardRef<MapViewRef, MapViewProps>(function MapView(
   }, [map, padding, initialZoom, offsetCenter]);
 
   const handleDragStart = () => {
-    isDragging.current = true;
+    setIsDragging(true);
     wasGesture.current = true;
   };
 
   const handleDragEnd = () => {
-    isDragging.current = false;
+    setIsDragging(false);
   };
 
   const handleCameraChanged = (event: MapCameraChangedEvent) => {
@@ -272,7 +272,7 @@ export const MapView = forwardRef<MapViewRef, MapViewProps>(function MapView(
         longitude: logicalCenter.lng,
       },
       zoom: event.detail.zoom,
-      gesture: isDragging.current,
+      gesture: isDragging,
     };
     onCameraMove?.(createSyntheticEvent(payload));
   };
@@ -310,7 +310,7 @@ export const MapView = forwardRef<MapViewRef, MapViewProps>(function MapView(
     : undefined;
 
   return (
-    <MapIdContext.Provider value={id}>
+    <MapContext.Provider value={{ map, isDragging }}>
       <View ref={containerRef} style={style}>
         <Map
           id={id}
@@ -332,6 +332,6 @@ export const MapView = forwardRef<MapViewRef, MapViewProps>(function MapView(
           {children}
         </Map>
       </View>
-    </MapIdContext.Provider>
+    </MapContext.Provider>
   );
 });

--- a/src/components/Polyline.web.tsx
+++ b/src/components/Polyline.web.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useMap } from '@vis.gl/react-google-maps';
-import { useMapId } from '../MapProvider.web';
+import { useMapContext } from '../MapProvider.web';
 import type { PolylineProps } from './Polyline';
 
 const ANIMATION_DURATION = 1500;
@@ -43,10 +42,10 @@ export function Polyline({
   zIndex,
 }: PolylineProps) {
   const resolvedZIndex = zIndex ?? (animated ? 1 : 0);
-  const mapId = useMapId();
-  const map = useMap(mapId);
+  const { map, isDragging } = useMapContext();
   const polylinesRef = useRef<google.maps.Polyline[]>([]);
   const animationRef = useRef<number>(0);
+  const isPausedRef = useRef(false);
 
   const colors = useMemo(
     () =>
@@ -133,6 +132,11 @@ export function Polyline({
     };
   }, []);
 
+  // Pause/resume animation during drag
+  useEffect(() => {
+    isPausedRef.current = isDragging;
+  }, [isDragging]);
+
   // Main effect
   useEffect(() => {
     if (!propsRef.current.map || coordinates.length === 0) return;
@@ -153,6 +157,11 @@ export function Polyline({
     const cycleDuration = ANIMATION_DURATION * 2;
 
     const animate = (time: number) => {
+      if (isPausedRef.current) {
+        animationRef.current = requestAnimationFrame(animate);
+        return;
+      }
+
       const progress = (time % cycleDuration) / ANIMATION_DURATION;
       const startIdx = progress <= 1 ? 0 : (progress - 1) * totalPoints;
       const endIdx = progress <= 1 ? progress * totalPoints : totalPoints;


### PR DESCRIPTION
## Summary
Pause polyline animation during map drag on web, matching iOS/Android behavior from #20.

## Type of Change
- [x] Bug fix

## Test Plan
Tested polyline animation pauses when dragging the map on web.

## Checklist
- [ ] iOS
- [ ] Android
- [x] Web