### PR TITLE
feat: add animatedOptions to Polyline

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
+++ b/android/src/main/java/com/luggmaps/LuggGoogleMapView.kt
@@ -337,6 +337,7 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
       coordinates = polylineView.coordinates
       strokeColors = polylineView.strokeColors
       strokeWidth = polylineView.strokeWidth.dpToPx()
+      animatedOptions = polylineView.animatedOptions
       animated = polylineView.animated
       update()
     }
@@ -364,6 +365,7 @@ class LuggGoogleMapView(private val reactContext: ThemedReactContext) :
       coordinates = polylineView.coordinates
       strokeColors = polylineView.strokeColors
       strokeWidth = polylineView.strokeWidth.dpToPx()
+      animatedOptions = polylineView.animatedOptions
       animated = polylineView.animated
       update()
     }

--- a/android/src/main/java/com/luggmaps/LuggPolylineView.kt
+++ b/android/src/main/java/com/luggmaps/LuggPolylineView.kt
@@ -12,6 +12,13 @@ interface LuggPolylineViewDelegate {
   fun polylineViewDidUpdate(polylineView: LuggPolylineView)
 }
 
+data class AnimatedOptions(
+  val duration: Long = 2150L,
+  val easing: String = "linear",
+  val trailLength: Float = 1f,
+  val delay: Long = 0L
+)
+
 class LuggPolylineView(context: Context) : ReactViewGroup(context) {
   var coordinates: List<LatLng> = emptyList()
     private set
@@ -23,6 +30,9 @@ class LuggPolylineView(context: Context) : ReactViewGroup(context) {
     private set
 
   var animated: Boolean = false
+    private set
+
+  var animatedOptions: AnimatedOptions = AnimatedOptions()
     private set
 
   var zIndex: Float = 0f
@@ -56,6 +66,10 @@ class LuggPolylineView(context: Context) : ReactViewGroup(context) {
 
   fun setAnimated(value: Boolean) {
     animated = value
+  }
+
+  fun setAnimatedOptions(options: AnimatedOptions) {
+    animatedOptions = options
   }
 
   fun setZIndex(value: Float) {

--- a/android/src/main/java/com/luggmaps/LuggPolylineViewManager.kt
+++ b/android/src/main/java/com/luggmaps/LuggPolylineViewManager.kt
@@ -1,6 +1,7 @@
 package com.luggmaps
 
 import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
@@ -63,6 +64,21 @@ class LuggPolylineViewManager :
   @ReactProp(name = "animated", defaultBoolean = false)
   override fun setAnimated(view: LuggPolylineView, value: Boolean) {
     view.setAnimated(value)
+  }
+
+  @ReactProp(name = "animatedOptions")
+  override fun setAnimatedOptions(view: LuggPolylineView, value: ReadableMap?) {
+    val options = if (value != null) {
+      AnimatedOptions(
+        duration = if (value.hasKey("duration")) value.getDouble("duration").toLong() else 2150L,
+        easing = if (value.hasKey("easing")) value.getString("easing") ?: "linear" else "linear",
+        trailLength = if (value.hasKey("trailLength")) value.getDouble("trailLength").toFloat() else 1f,
+        delay = if (value.hasKey("delay")) value.getDouble("delay").toLong() else 0L
+      )
+    } else {
+      AnimatedOptions()
+    }
+    view.setAnimatedOptions(options)
   }
 
   @ReactProp(name = "zIndex", defaultFloat = 0f)

--- a/android/src/main/java/com/luggmaps/core/PolylineAnimator.kt
+++ b/android/src/main/java/com/luggmaps/core/PolylineAnimator.kt
@@ -1,5 +1,6 @@
 package com.luggmaps.core
 
+import android.animation.TimeInterpolator
 import android.animation.ValueAnimator
 import android.graphics.Color
 import android.location.Location
@@ -8,6 +9,7 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Polyline
 import com.google.android.gms.maps.model.StrokeStyle
 import com.google.android.gms.maps.model.StyleSpan
+import com.luggmaps.AnimatedOptions
 import kotlin.math.floor
 import kotlin.math.min
 
@@ -22,6 +24,14 @@ class PolylineAnimator {
     }
   var strokeColors: List<Int> = listOf(Color.BLACK)
   var strokeWidth: Float = 1f
+  var animatedOptions: AnimatedOptions = AnimatedOptions()
+    set(value) {
+      if (field == value) return
+      field = value
+      if (animated) {
+        restartAnimation()
+      }
+    }
 
   var animated: Boolean = false
     set(value) {
@@ -44,6 +54,22 @@ class PolylineAnimator {
   private val reusablePoints = ArrayList<LatLng>()
   private val reusableSpans = ArrayList<StyleSpan>()
 
+  private fun restartAnimation() {
+    stopAnimation()
+    startAnimation()
+  }
+
+  private fun getInterpolator(): TimeInterpolator {
+    return when (animatedOptions.easing) {
+      "easeIn" -> TimeInterpolator { t -> t * t }
+      "easeOut" -> TimeInterpolator { t -> t * (2 - t) }
+      "easeInOut" -> TimeInterpolator { t ->
+        if (t < 0.5f) 2 * t * t else -1 + (4 - 2 * t) * t
+      }
+      else -> LinearInterpolator()
+    }
+  }
+
   fun update() {
     if (animated) return
 
@@ -64,10 +90,14 @@ class PolylineAnimator {
 
     computeCumulativeDistances()
 
-    animator = ValueAnimator.ofFloat(0f, 2.15f).apply {
-      duration = 2150
+    val trailLength = animatedOptions.trailLength.coerceIn(0.01f, 1f)
+    val endValue = if (trailLength < 1f) 1f else 2.15f
+
+    animator = ValueAnimator.ofFloat(0f, endValue).apply {
+      duration = animatedOptions.duration
+      startDelay = animatedOptions.delay
       repeatCount = ValueAnimator.INFINITE
-      interpolator = LinearInterpolator()
+      interpolator = getInterpolator()
       addUpdateListener { animation ->
         animationProgress = animation.animatedValue as Float
         updateAnimatedPolyline()
@@ -158,12 +188,16 @@ class PolylineAnimator {
       return
     }
 
-    val progress = min(animationProgress, 2f)
+    val trailLength = animatedOptions.trailLength.coerceIn(0.01f, 1f)
+    val progress = min(animationProgress, if (trailLength < 1f) 1f else 2f)
 
     val headDist: Float
     val tailDist: Float
 
-    if (progress <= 1f) {
+    if (trailLength < 1f) {
+      headDist = progress * totalLength
+      tailDist = maxOf(0f, headDist - totalLength * trailLength)
+    } else if (progress <= 1f) {
       tailDist = 0f
       headDist = progress * totalLength
     } else {

--- a/example/bare/ios/Podfile.lock
+++ b/example/bare/ios/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - hermes-engine (0.14.0):
     - hermes-engine/Pre-built (= 0.14.0)
   - hermes-engine/Pre-built (0.14.0)
-  - LuggMaps (0.2.0-alpha.18):
+  - LuggMaps (0.2.0-alpha.19):
     - boost
     - DoubleConversion
     - fast_float
@@ -3017,7 +3017,7 @@ SPEC CHECKSUMS:
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   GoogleMaps: 0608099d4870cac8754bdba9b6953db543432438
   hermes-engine: 3515eff1a2de44b79dfa94a03d1adeed40f0dafe
-  LuggMaps: 75d44f3004128ff6e23a67531a18a621d922e55d
+  LuggMaps: f1808eb2e560a2dd154d5a415d0eb4e36a0cc131
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 2b70c6e3abe00396cefd8913efbf6a2db01a2b36
   RCTRequired: f3540eee8094231581d40c5c6d41b0f170237a81

--- a/example/shared/src/components/Route.tsx
+++ b/example/shared/src/components/Route.tsx
@@ -76,6 +76,10 @@ export const Route = ({ coordinates }: SmoothedRouteProps) => {
         strokeColors={['#B321E0', '#3744FF']}
         coordinates={coordinates}
         strokeWidth={6}
+        animatedOptions={{
+          easing: 'easeInOut',
+          duration: 3000,
+        }}
         animated
       />
     </>

--- a/ios/LuggAppleMapView.mm
+++ b/ios/LuggAppleMapView.mm
@@ -379,6 +379,7 @@ using namespace luggmaps::events;
     renderer.strokeColor = polylineView.strokeColors.firstObject;
     renderer.strokeColors =
         polylineView.strokeColors.count > 1 ? polylineView.strokeColors : nil;
+    renderer.animatedOptions = polylineView.animatedOptions;
     renderer.animated = polylineView.animated;
     return;
   }
@@ -548,6 +549,7 @@ using namespace luggmaps::events;
       if (colors.count > 1) {
         renderer.strokeColors = colors;
       }
+      renderer.animatedOptions = polylineView.animatedOptions;
       renderer.animated = polylineView.animated;
       polylineView.renderer = renderer;
       return renderer;

--- a/ios/LuggGoogleMapView.mm
+++ b/ios/LuggGoogleMapView.mm
@@ -339,6 +339,7 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
   if (animator) {
     animator.coordinates = polylineView.coordinates;
     animator.strokeColors = polylineView.strokeColors;
+    animator.animatedOptions = polylineView.animatedOptions;
     animator.animated = polylineView.animated;
     [animator update];
   }
@@ -370,6 +371,7 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
   animator.polyline = polyline;
   animator.coordinates = polylineView.coordinates;
   animator.strokeColors = polylineView.strokeColors;
+  animator.animatedOptions = polylineView.animatedOptions;
   animator.animated = polylineView.animated;
   [animator update];
 

--- a/ios/LuggPolylineView.h
+++ b/ios/LuggPolylineView.h
@@ -1,6 +1,7 @@
 #import <CoreLocation/CoreLocation.h>
 #import <React/RCTViewComponentView.h>
 #import <UIKit/UIKit.h>
+#import "core/PolylineAnimatorBase.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSArray<CLLocation *> *coordinates;
 @property(nonatomic, readonly) NSArray<UIColor *> *strokeColors;
 @property(nonatomic, readonly) BOOL animated;
+@property(nonatomic, readonly, nullable) PolylineAnimatedOptions *animatedOptions;
 @property(nonatomic, readonly) CGFloat strokeWidth;
 @property(nonatomic, readonly) NSInteger zIndex;
 @property(nonatomic, weak, nullable) id<LuggPolylineViewDelegate> delegate;

--- a/ios/LuggPolylineView.mm
+++ b/ios/LuggPolylineView.mm
@@ -17,6 +17,7 @@ using namespace facebook::react;
   NSArray<CLLocation *> *_coordinates;
   NSArray<UIColor *> *_strokeColors;
   BOOL _animated;
+  PolylineAnimatedOptions *_animatedOptions;
   CGFloat _strokeWidth;
   NSInteger _zIndex;
 }
@@ -72,6 +73,15 @@ using namespace facebook::react;
   }
 
   _animated = newViewProps.animated;
+
+  const auto &opts = newViewProps.animatedOptions;
+  PolylineAnimatedOptions *options = [[PolylineAnimatedOptions alloc] init];
+  options.duration = opts.duration > 0 ? opts.duration : 2150;
+  options.trailLength = (opts.trailLength > 0 && opts.trailLength <= 1.0) ? opts.trailLength : 1.0;
+  options.delay = opts.delay;
+  options.easing = !opts.easing.empty() ? [NSString stringWithUTF8String:opts.easing.c_str()] : @"linear";
+  _animatedOptions = options;
+
   _strokeWidth = newViewProps.strokeWidth > 0 ? newViewProps.strokeWidth : 1.0;
   _zIndex = newViewProps.zIndex.value_or(0);
 }
@@ -96,6 +106,10 @@ using namespace facebook::react;
 
 - (BOOL)animated {
   return _animated;
+}
+
+- (PolylineAnimatedOptions *)animatedOptions {
+  return _animatedOptions;
 }
 
 - (CGFloat)strokeWidth {

--- a/ios/core/GMSPolylineAnimator.h
+++ b/ios/core/GMSPolylineAnimator.h
@@ -5,6 +5,7 @@
 
 @property(nonatomic, weak) GMSPolyline *polyline;
 @property(nonatomic, assign) BOOL animated;
+@property(nonatomic, strong) PolylineAnimatedOptions *animatedOptions;
 
 - (void)update;
 - (void)pause;

--- a/ios/core/GMSPolylineAnimator.m
+++ b/ios/core/GMSPolylineAnimator.m
@@ -30,9 +30,12 @@
   CADisplayLink *_displayLink;
   GMSDisplayLinkProxy *_displayLinkProxy;
   CGFloat _animationProgress;
+  CGFloat _delayRemaining;
   NSArray<NSNumber *> *_cumulativeDistances;
   CGFloat _totalLength;
 }
+
+@synthesize animatedOptions = _animatedOptions;
 
 - (void)dealloc {
   [self stopAnimation];
@@ -59,12 +62,21 @@
   }
 }
 
+- (void)setAnimatedOptions:(PolylineAnimatedOptions *)animatedOptions {
+  _animatedOptions = animatedOptions ?: [PolylineAnimatedOptions defaultOptions];
+  if (_animated && _displayLink) {
+    [self stopAnimation];
+    [self startAnimation];
+  }
+}
+
 - (void)startAnimation {
   if (_displayLink) {
     return;
   }
   [self computeCumulativeDistances];
   _animationProgress = 0;
+  _delayRemaining = self.animatedOptions.delay / 1000.0;
   _displayLinkProxy = [[GMSDisplayLinkProxy alloc] initWithTarget:self selector:@selector(animationTick:)];
   _displayLink = [CADisplayLink displayLinkWithTarget:_displayLinkProxy selector:@selector(tick:)];
   [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
@@ -101,11 +113,23 @@
 }
 
 - (void)animationTick:(CADisplayLink *)displayLink {
-  CGFloat speed = displayLink.duration / 1.0;
+  if (_delayRemaining > 0) {
+    _delayRemaining -= displayLink.duration;
+    return;
+  }
+
+  CGFloat duration = self.animatedOptions.duration / 1000.0;
+  if (duration <= 0) duration = 2.15;
+
+  CGFloat trailLength = MAX(0.01, MIN(1.0, self.animatedOptions.trailLength));
+  CGFloat maxProgress = (trailLength < 1.0) ? 1.0 : 2.15;
+
+  CGFloat speed = displayLink.duration / duration;
   _animationProgress += speed;
 
-  if (_animationProgress >= 2.15) {
+  if (_animationProgress >= maxProgress) {
     _animationProgress = 0;
+    _delayRemaining = self.animatedOptions.delay / 1000.0;
   }
 
   [self updateAnimatedPolyline];
@@ -175,14 +199,21 @@
     return;
   }
 
-  CGFloat progress = MIN(_animationProgress, 2.0);
+  CGFloat trailLength = MAX(0.01, MIN(1.0, self.animatedOptions.trailLength));
+  CGFloat maxProgress = (trailLength < 1.0) ? 1.0 : 2.0;
+  CGFloat progress = MIN(_animationProgress, maxProgress);
+  CGFloat easedProgress = [self applyEasing:progress / maxProgress] * maxProgress;
+
   CGFloat headDist, tailDist;
 
-  if (progress <= 1.0) {
+  if (trailLength < 1.0) {
+    headDist = easedProgress * _totalLength;
+    tailDist = MAX(0, headDist - _totalLength * trailLength);
+  } else if (easedProgress <= 1.0) {
     tailDist = 0;
-    headDist = progress * _totalLength;
+    headDist = easedProgress * _totalLength;
   } else {
-    CGFloat shrinkProgress = progress - 1.0;
+    CGFloat shrinkProgress = easedProgress - 1.0;
     tailDist = shrinkProgress * _totalLength;
     headDist = _totalLength;
   }

--- a/ios/core/MKPolylineAnimator.h
+++ b/ios/core/MKPolylineAnimator.h
@@ -1,4 +1,5 @@
 #import <MapKit/MapKit.h>
+#import "PolylineAnimatorBase.h"
 
 @interface MKPolylineAnimator : MKOverlayPathRenderer
 
@@ -6,6 +7,7 @@
 
 @property(nonatomic, strong) NSArray<UIColor *> *strokeColors;
 @property(nonatomic, assign) BOOL animated;
+@property(nonatomic, strong) PolylineAnimatedOptions *animatedOptions;
 
 - (void)updatePolyline:(MKPolyline *)polyline;
 - (void)pause;

--- a/ios/core/MKPolylineAnimator.m
+++ b/ios/core/MKPolylineAnimator.m
@@ -31,6 +31,7 @@
   CADisplayLink *_displayLink;
   MKDisplayLinkProxy *_displayLinkProxy;
   CGFloat _animationProgress;
+  CGFloat _delayRemaining;
   NSArray<NSNumber *> *_cumulativeDistances;
   CGFloat _totalLength;
   CGColorSpaceRef _colorSpace;
@@ -41,10 +42,19 @@
   if (self) {
     _polyline = polyline;
     _animationProgress = 0;
+    _animatedOptions = [PolylineAnimatedOptions defaultOptions];
     _colorSpace = CGColorSpaceCreateDeviceRGB();
     [self createPath];
   }
   return self;
+}
+
+- (void)setAnimatedOptions:(PolylineAnimatedOptions *)animatedOptions {
+  _animatedOptions = animatedOptions ?: [PolylineAnimatedOptions defaultOptions];
+  if (_animated && _displayLink) {
+    [self stopAnimation];
+    [self startAnimation];
+  }
 }
 
 - (void)dealloc {
@@ -74,6 +84,7 @@
   }
   [self computeCumulativeDistances];
   _animationProgress = 0;
+  _delayRemaining = _animatedOptions.delay / 1000.0;
   _displayLinkProxy = [[MKDisplayLinkProxy alloc] initWithTarget:self selector:@selector(animationTick:)];
   _displayLink = [CADisplayLink displayLinkWithTarget:_displayLinkProxy selector:@selector(tick:)];
   [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
@@ -125,12 +136,37 @@
   return MIN(left, _cumulativeDistances.count - 2);
 }
 
+- (CGFloat)applyEasing:(CGFloat)t {
+  NSString *easing = _animatedOptions.easing ?: @"linear";
+
+  if ([easing isEqualToString:@"easeIn"]) {
+    return t * t;
+  } else if ([easing isEqualToString:@"easeOut"]) {
+    return t * (2 - t);
+  } else if ([easing isEqualToString:@"easeInOut"]) {
+    return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+  }
+  return t;
+}
+
 - (void)animationTick:(CADisplayLink *)displayLink {
-  CGFloat speed = displayLink.duration / 1.0;
+  if (_delayRemaining > 0) {
+    _delayRemaining -= displayLink.duration;
+    return;
+  }
+
+  CGFloat duration = _animatedOptions.duration / 1000.0;
+  if (duration <= 0) duration = 2.15;
+
+  CGFloat trailLength = MAX(0.01, MIN(1.0, _animatedOptions.trailLength));
+  CGFloat maxProgress = (trailLength < 1.0) ? 1.0 : 2.15;
+
+  CGFloat speed = displayLink.duration / duration;
   _animationProgress += speed;
 
-  if (_animationProgress >= 2.15) {
+  if (_animationProgress >= maxProgress) {
     _animationProgress = 0;
+    _delayRemaining = _animatedOptions.delay / 1000.0;
   }
 
   MKMapRect bounds = _polyline.boundingMapRect;
@@ -214,14 +250,21 @@
 
   // Snake animation: grow from start, then shrink from start
   if (_animated && _polyline.pointCount > 1 && _totalLength > 0) {
-    CGFloat progress = MIN(_animationProgress, 2.0);
+    CGFloat trailLength = MAX(0.01, MIN(1.0, _animatedOptions.trailLength));
+    CGFloat maxProgress = (trailLength < 1.0) ? 1.0 : 2.0;
+    CGFloat progress = MIN(_animationProgress, maxProgress);
+    CGFloat easedProgress = [self applyEasing:progress / maxProgress] * maxProgress;
+
     CGFloat headDist, tailDist;
 
-    if (progress <= 1.0) {
+    if (trailLength < 1.0) {
+      headDist = easedProgress * _totalLength;
+      tailDist = MAX(0, headDist - _totalLength * trailLength);
+    } else if (easedProgress <= 1.0) {
       tailDist = 0;
-      headDist = progress * _totalLength;
+      headDist = easedProgress * _totalLength;
     } else {
-      CGFloat shrinkProgress = progress - 1.0;
+      CGFloat shrinkProgress = easedProgress - 1.0;
       tailDist = shrinkProgress * _totalLength;
       headDist = _totalLength;
     }

--- a/ios/core/PolylineAnimatorBase.h
+++ b/ios/core/PolylineAnimatorBase.h
@@ -2,11 +2,23 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+@interface PolylineAnimatedOptions : NSObject
+
+@property(nonatomic, assign) NSTimeInterval duration;
+@property(nonatomic, copy) NSString *easing;
+@property(nonatomic, assign) CGFloat trailLength;
+@property(nonatomic, assign) NSTimeInterval delay;
+
++ (instancetype)defaultOptions;
+
+@end
+
 @protocol PolylineAnimator <NSObject>
 
 @property(nonatomic, strong) NSArray<CLLocation *> *coordinates;
 @property(nonatomic, strong) NSArray<UIColor *> *strokeColors;
 @property(nonatomic, assign) BOOL animated;
+@property(nonatomic, strong) PolylineAnimatedOptions *animatedOptions;
 
 - (void)update;
 
@@ -16,7 +28,9 @@
 
 @property(nonatomic, strong) NSArray<CLLocation *> *coordinates;
 @property(nonatomic, strong) NSArray<UIColor *> *strokeColors;
+@property(nonatomic, strong) PolylineAnimatedOptions *animatedOptions;
 
 - (UIColor *)colorAtGradientPosition:(CGFloat)position;
+- (CGFloat)applyEasing:(CGFloat)t;
 
 @end

--- a/ios/core/PolylineAnimatorBase.m
+++ b/ios/core/PolylineAnimatorBase.m
@@ -1,6 +1,39 @@
 #import "PolylineAnimatorBase.h"
 
+@implementation PolylineAnimatedOptions
+
++ (instancetype)defaultOptions {
+  PolylineAnimatedOptions *options = [[PolylineAnimatedOptions alloc] init];
+  options.duration = 2.15;
+  options.easing = @"linear";
+  options.trailLength = 1.0;
+  options.delay = 0;
+  return options;
+}
+
+@end
+
 @implementation PolylineAnimatorBase
+
+- (instancetype)init {
+  if (self = [super init]) {
+    _animatedOptions = [PolylineAnimatedOptions defaultOptions];
+  }
+  return self;
+}
+
+- (CGFloat)applyEasing:(CGFloat)t {
+  NSString *easing = self.animatedOptions.easing ?: @"linear";
+
+  if ([easing isEqualToString:@"easeIn"]) {
+    return t * t;
+  } else if ([easing isEqualToString:@"easeOut"]) {
+    return t * (2 - t);
+  } else if ([easing isEqualToString:@"easeInOut"]) {
+    return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+  }
+  return t;
+}
 
 - (UIColor *)colorAtGradientPosition:(CGFloat)position {
   if (!_strokeColors || _strokeColors.count == 0) {

--- a/src/components/Polyline.tsx
+++ b/src/components/Polyline.tsx
@@ -4,6 +4,32 @@ import { StyleSheet } from 'react-native';
 import LuggPolylineViewNativeComponent from '../fabric/LuggPolylineViewNativeComponent';
 import type { Coordinate } from '../types';
 
+export type PolylineEasing = 'linear' | 'easeIn' | 'easeOut' | 'easeInOut';
+
+export interface PolylineAnimatedOptions {
+  /**
+   * Animation duration in milliseconds
+   * @default 2150
+   */
+  duration?: number;
+  /**
+   * Easing function for the animation
+   * @default 'linear'
+   */
+  easing?: PolylineEasing;
+  /**
+   * Portion of the line visible as trail (0-1)
+   * 1.0 = full snake effect, 0.2 = short worm
+   * @default 1.0
+   */
+  trailLength?: number;
+  /**
+   * Delay before animation starts in milliseconds
+   * @default 0
+   */
+  delay?: number;
+}
+
 export interface PolylineProps {
   /**
    * Array of coordinates forming the polyline
@@ -22,6 +48,10 @@ export interface PolylineProps {
    */
   animated?: boolean;
   /**
+   * Animation configuration options
+   */
+  animatedOptions?: PolylineAnimatedOptions;
+  /**
    * Z-index for layering polylines
    */
   zIndex?: number;
@@ -34,6 +64,7 @@ export class Polyline extends React.Component<PolylineProps> {
       strokeColors,
       strokeWidth,
       animated = false,
+      animatedOptions,
       zIndex,
     } = this.props;
 
@@ -44,6 +75,7 @@ export class Polyline extends React.Component<PolylineProps> {
         strokeColors={strokeColors}
         strokeWidth={strokeWidth}
         animated={animated}
+        animatedOptions={animatedOptions}
       />
     );
   }

--- a/src/components/Polyline.web.tsx
+++ b/src/components/Polyline.web.tsx
@@ -1,8 +1,21 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMapContext } from '../MapProvider.web';
-import type { PolylineProps } from './Polyline';
+import type { PolylineProps, PolylineEasing } from './Polyline';
 
-const ANIMATION_DURATION = 1500;
+const DEFAULT_DURATION = 2150;
+
+function applyEasing(t: number, easing: PolylineEasing = 'linear'): number {
+  switch (easing) {
+    case 'easeIn':
+      return t * t;
+    case 'easeOut':
+      return t * (2 - t);
+    case 'easeInOut':
+      return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+    default:
+      return t;
+  }
+}
 
 function interpolateColor(color1: string, color2: string, t: number): string {
   const hex = (c: string) => parseInt(c, 16);
@@ -39,6 +52,7 @@ export function Polyline({
   strokeColors,
   strokeWidth = 1,
   animated,
+  animatedOptions,
   zIndex,
 }: PolylineProps) {
   const resolvedZIndex = zIndex ?? (animated ? 1 : 0);
@@ -153,18 +167,60 @@ export function Polyline({
       return;
     }
 
+    const duration = animatedOptions?.duration ?? DEFAULT_DURATION;
+    const easing = animatedOptions?.easing ?? 'linear';
+    const trailLength = Math.max(0.01, Math.min(1, animatedOptions?.trailLength ?? 1));
+    const delay = animatedOptions?.delay ?? 0;
+
     const totalPoints = fullPath.length;
-    const cycleDuration = ANIMATION_DURATION * 2;
+    const useTrailMode = trailLength < 1;
+    const cycleDuration = useTrailMode ? duration : duration * 2;
+
+    let startTime: number | null = null;
+    let delayRemaining = delay;
 
     const animate = (time: number) => {
       if (isPausedRef.current) {
+        startTime = null;
         animationRef.current = requestAnimationFrame(animate);
         return;
       }
 
-      const progress = (time % cycleDuration) / ANIMATION_DURATION;
-      const startIdx = progress <= 1 ? 0 : (progress - 1) * totalPoints;
-      const endIdx = progress <= 1 ? progress * totalPoints : totalPoints;
+      if (startTime === null) {
+        startTime = time;
+      }
+
+      const elapsed = time - startTime;
+
+      if (delayRemaining > 0) {
+        if (elapsed < delayRemaining) {
+          animationRef.current = requestAnimationFrame(animate);
+          return;
+        }
+        startTime = time - (elapsed - delayRemaining);
+        delayRemaining = 0;
+      }
+
+      const rawProgress = ((time - startTime) % cycleDuration) / duration;
+      const maxProgress = useTrailMode ? 1 : 2;
+      const clampedProgress = Math.min(rawProgress, maxProgress);
+      const easedProgress = applyEasing(clampedProgress / maxProgress, easing) * maxProgress;
+
+      let startIdx: number;
+      let endIdx: number;
+
+      if (useTrailMode) {
+        endIdx = easedProgress * totalPoints;
+        startIdx = Math.max(0, endIdx - trailLength * totalPoints);
+      } else {
+        startIdx = easedProgress <= 1 ? 0 : (easedProgress - 1) * totalPoints;
+        endIdx = easedProgress <= 1 ? easedProgress * totalPoints : totalPoints;
+      }
+
+      if (rawProgress >= maxProgress) {
+        delayRemaining = delay;
+        startTime = time;
+      }
 
       const partialPath: google.maps.LatLngLiteral[] = [];
       const startFloor = Math.floor(startIdx);
@@ -214,7 +270,7 @@ export function Polyline({
     animationRef.current = requestAnimationFrame(animate);
 
     return () => cancelAnimationFrame(animationRef.current);
-  }, [coordinates, animated, hasGradient, updatePath, mapReady]);
+  }, [coordinates, animated, animatedOptions, hasGradient, updatePath, mapReady]);
 
   return null;
 }

--- a/src/fabric/LuggPolylineViewNativeComponent.ts
+++ b/src/fabric/LuggPolylineViewNativeComponent.ts
@@ -7,11 +7,19 @@ export interface Coordinate {
   longitude: Double;
 }
 
+export interface AnimatedOptions {
+  duration?: Double;
+  easing?: string;
+  trailLength?: Double;
+  delay?: Double;
+}
+
 export interface NativeProps extends ViewProps {
   coordinates: ReadonlyArray<Coordinate>;
   strokeColors?: ReadonlyArray<ColorValue>;
   strokeWidth?: Double;
   animated?: boolean;
+  animatedOptions?: AnimatedOptions;
 }
 
 export default codegenNativeComponent<NativeProps>(


### PR DESCRIPTION
## Summary
Add `animatedOptions` prop to Polyline for configurable animation with duration, easing, trailLength, and delay options.

### New Type
```typescript
interface PolylineAnimatedOptions {
  duration?: number;      // ms, default 2150
  easing?: 'linear' | 'easeIn' | 'easeOut' | 'easeInOut';
  trailLength?: number;   // 0-1, default 1.0 (full snake)
  delay?: number;         // ms before animation starts
}
```

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Test Plan
Tested on iOS (Google Maps & MapKit), Android, and Web:
- `animated: true` without options works as before
- Custom duration changes animation speed
- Easing functions work correctly
- `trailLength: 0.3` creates short worm effect
- Delay works before animation starts

## Checklist
- [x] iOS
- [x] Android
- [x] Web