### PR TITLE
feat(android): add myLocationButtonEnabled prop to control native location button

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggMapView.kt
+++ b/android/src/main/java/com/luggmaps/LuggMapView.kt
@@ -50,6 +50,7 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
   private var rotateEnabled: Boolean = true
   private var pitchEnabled: Boolean = true
   private var userLocationEnabled: Boolean = false
+  private var myLocationButtonEnabled: Boolean = false
   private var minZoom: Double? = null
   private var maxZoom: Double? = null
   private var edgeInsets: EdgeInsets = EdgeInsets()
@@ -147,6 +148,7 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
     provider?.setRotateEnabled(rotateEnabled)
     provider?.setPitchEnabled(pitchEnabled)
     provider?.setUserLocationEnabled(userLocationEnabled)
+    provider?.setMyLocationButtonEnabled(myLocationButtonEnabled)
     provider?.setTheme(theme)
     minZoom?.let { provider?.setMinZoom(it) }
     maxZoom?.let { provider?.setMaxZoom(it) }
@@ -196,6 +198,11 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
   fun setUserLocationEnabled(enabled: Boolean) {
     userLocationEnabled = enabled
     provider?.setUserLocationEnabled(enabled)
+  }
+
+  fun setMyLocationButtonEnabled(enabled: Boolean) {
+    myLocationButtonEnabled = enabled
+    provider?.setMyLocationButtonEnabled(enabled)
   }
 
   fun setMinZoom(zoom: Double) {

--- a/android/src/main/java/com/luggmaps/LuggMapViewManager.kt
+++ b/android/src/main/java/com/luggmaps/LuggMapViewManager.kt
@@ -113,6 +113,11 @@ class LuggMapViewManager :
     view.setUserLocationEnabled(value)
   }
 
+  @ReactProp(name = "myLocationButtonEnabled", defaultBoolean = false)
+  override fun setMyLocationButtonEnabled(view: LuggMapView, value: Boolean) {
+    view.setMyLocationButtonEnabled(value)
+  }
+
   @ReactProp(name = "minZoom")
   override fun setMinZoom(view: LuggMapView, value: Double) {
     view.setMinZoom(value)

--- a/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
+++ b/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
@@ -53,6 +53,7 @@ class GoogleMapProvider(private val context: Context) :
   private var rotateEnabled: Boolean = true
   private var pitchEnabled: Boolean = true
   private var userLocationEnabled: Boolean = false
+  private var myLocationButtonEnabled: Boolean = false
 
   // Zoom limits
   private var minZoom: Float? = null
@@ -178,6 +179,11 @@ class GoogleMapProvider(private val context: Context) :
         context.checkSelfPermission(android.Manifest.permission.ACCESS_COARSE_LOCATION) ==
         android.content.pm.PackageManager.PERMISSION_GRANTED
     googleMap?.isMyLocationEnabled = userLocationEnabled && hasPermission
+  }
+
+  override fun setMyLocationButtonEnabled(enabled: Boolean) {
+    myLocationButtonEnabled = enabled
+    googleMap?.uiSettings?.isMyLocationButtonEnabled = enabled
   }
 
   override fun setTheme(value: String) {
@@ -478,6 +484,7 @@ class GoogleMapProvider(private val context: Context) :
         context.checkSelfPermission(android.Manifest.permission.ACCESS_COARSE_LOCATION) ==
         android.content.pm.PackageManager.PERMISSION_GRANTED
     googleMap?.isMyLocationEnabled = userLocationEnabled && hasPermission
+    googleMap?.uiSettings?.isMyLocationButtonEnabled = myLocationButtonEnabled
   }
 
   // endregion

--- a/android/src/main/java/com/luggmaps/core/MapProviderDelegate.kt
+++ b/android/src/main/java/com/luggmaps/core/MapProviderDelegate.kt
@@ -25,6 +25,7 @@ interface MapProvider {
   fun setRotateEnabled(enabled: Boolean)
   fun setPitchEnabled(enabled: Boolean)
   fun setUserLocationEnabled(enabled: Boolean)
+  fun setMyLocationButtonEnabled(enabled: Boolean)
   fun setTheme(value: String)
   fun setMinZoom(zoom: Double)
   fun setMaxZoom(zoom: Double)

--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -81,6 +81,7 @@ export class MapView
       pitchEnabled,
       edgeInsets,
       userLocationEnabled,
+      myLocationButtonEnabled,
       theme,
       onCameraMove,
       onCameraIdle,
@@ -105,6 +106,7 @@ export class MapView
         pitchEnabled={pitchEnabled}
         edgeInsets={edgeInsets}
         userLocationEnabled={userLocationEnabled}
+        myLocationButtonEnabled={myLocationButtonEnabled}
         theme={theme}
         onCameraMove={onCameraMove}
         onCameraIdle={onCameraIdle}

--- a/src/MapView.types.ts
+++ b/src/MapView.types.ts
@@ -101,6 +101,11 @@ export interface MapViewProps extends ViewProps {
    */
   userLocationEnabled?: boolean;
   /**
+   * Show native my-location button when userLocationEnabled is true (Android only).
+   * @default false
+   */
+  myLocationButtonEnabled?: boolean;
+  /**
    * Map color theme
    * @default 'system'
    */

--- a/src/fabric/LuggMapViewNativeComponent.ts
+++ b/src/fabric/LuggMapViewNativeComponent.ts
@@ -51,6 +51,7 @@ export interface NativeProps extends ViewProps {
   pitchEnabled?: boolean;
   edgeInsets?: EdgeInsets;
   userLocationEnabled?: boolean;
+  myLocationButtonEnabled?: boolean;
   theme?: WithDefault<'light' | 'dark' | 'system', 'system'>;
   onCameraMove?: DirectEventHandler<CameraMoveEvent>;
   onCameraIdle?: DirectEventHandler<CameraIdleEvent>;


### PR DESCRIPTION
## Summary

The Google Maps Android SDK automatically shows a native "my location" button (crosshair icon, top-right corner) whenever `isMyLocationEnabled` is set to `true`. There was no way for consumers to hide this button — both `apps/app` and `apps/worker` use custom React Native location controls, making the native button always unwanted.

This adds a `myLocationButtonEnabled` prop (default `false`) that gives consumers explicit control over the native button visibility.

<img width="375" height="2220" alt="Screenshot_1770724950" src="https://github.com/user-attachments/assets/07ba60be-ff2c-41d1-b955-e08f624deb14" />
<img width="375" height="2400" alt="Screenshot_1770643889" src="https://github.com/user-attachments/assets/fe6e21c5-fc8b-428f-b75c-2438de51d99c" />


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Verified `myLocationButtonEnabled` defaults to `false` — native button is hidden when `userLocationEnabled={true}`
- Verified `myLocationButtonEnabled={true}` shows the native button
- Verified toggling the prop at runtime correctly shows/hides the button
- Tested on Android physical device in consumer app

## Screenshots / Videos

N/A

## Checklist

- [ ] iOS
- [x] Android
- [ ] Web
- [x] I have updated the documentation (types, JSDoc)

Made with [Cursor](https://cursor.com)