### PR TITLE
perf: optimize native animators, re-renders, and exports

### DIFF
--- a/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
+++ b/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
@@ -88,6 +88,9 @@ class GoogleMapProvider(private val context: Context) :
     pendingPolylineViews.clear()
     polylineAnimators.values.forEach { it.destroy() }
     polylineAnimators.clear()
+    googleMap?.setOnCameraMoveStartedListener(null)
+    googleMap?.setOnCameraMoveListener(null)
+    googleMap?.setOnCameraIdleListener(null)
     googleMap?.clear()
     googleMap = null
     _isMapReady = false

--- a/ios/core/MKPolylineAnimator.m
+++ b/ios/core/MKPolylineAnimator.m
@@ -35,6 +35,8 @@
   NSArray<NSNumber *> *_cumulativeDistances;
   CGFloat _totalLength;
   CGColorSpaceRef _colorSpace;
+  RGBAComponents *_colorCache;
+  NSUInteger _colorCacheCount;
 }
 
 - (id)initWithPolyline:(MKPolyline *)polyline {
@@ -59,6 +61,7 @@
 
 - (void)dealloc {
   [self stopAnimation];
+  free(_colorCache);
   if (_colorSpace) {
     CGColorSpaceRelease(_colorSpace);
     _colorSpace = NULL;
@@ -199,34 +202,60 @@
   self.path = path;
 }
 
-- (UIColor *)colorAtGradientPosition:(CGFloat)position {
-  if (!_strokeColors || _strokeColors.count == 0) {
-    return self.strokeColor;
+- (void)setStrokeColors:(NSArray<UIColor *> *)strokeColors {
+  _strokeColors = strokeColors;
+  [self rebuildColorCache];
+}
+
+- (void)rebuildColorCache {
+  free(_colorCache);
+  _colorCache = NULL;
+  _colorCacheCount = _strokeColors.count;
+  if (_colorCacheCount == 0) return;
+
+  _colorCache = (RGBAComponents *)malloc(sizeof(RGBAComponents) * _colorCacheCount);
+  for (NSUInteger i = 0; i < _colorCacheCount; i++) {
+    [_strokeColors[i] getRed:&_colorCache[i].r
+                       green:&_colorCache[i].g
+                        blue:&_colorCache[i].b
+                       alpha:&_colorCache[i].a];
   }
-  if (_strokeColors.count == 1) {
-    return _strokeColors[0];
+}
+
+- (void)colorAtGradientPosition:(CGFloat)position rgba:(RGBAComponents *)out {
+  if (_colorCacheCount == 0) {
+    CGFloat r, g, b, a;
+    [self.strokeColor getRed:&r green:&g blue:&b alpha:&a];
+    *out = (RGBAComponents){r, g, b, a};
+    return;
+  }
+  if (_colorCacheCount == 1) {
+    *out = _colorCache[0];
+    return;
   }
 
   position = MAX(0, MIN(1, position));
-  CGFloat scaledPos = position * (_strokeColors.count - 1);
-  NSUInteger index = (NSUInteger)floor(scaledPos);
+  CGFloat scaledPos = position * (_colorCacheCount - 1);
+  NSUInteger index = (NSUInteger)scaledPos;
   CGFloat t = scaledPos - index;
 
-  if (index >= _strokeColors.count - 1) {
-    return _strokeColors.lastObject;
+  if (index >= _colorCacheCount - 1) {
+    *out = _colorCache[_colorCacheCount - 1];
+    return;
   }
 
-  UIColor *c1 = _strokeColors[index];
-  UIColor *c2 = _strokeColors[index + 1];
+  RGBAComponents c1 = _colorCache[index];
+  RGBAComponents c2 = _colorCache[index + 1];
+  out->r = c1.r + (c2.r - c1.r) * t;
+  out->g = c1.g + (c2.g - c1.g) * t;
+  out->b = c1.b + (c2.b - c1.b) * t;
+  out->a = c1.a + (c2.a - c1.a) * t;
+}
 
-  CGFloat r1, g1, b1, a1, r2, g2, b2, a2;
-  [c1 getRed:&r1 green:&g1 blue:&b1 alpha:&a1];
-  [c2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
-
-  return [UIColor colorWithRed:r1 + (r2 - r1) * t
-                         green:g1 + (g2 - g1) * t
-                          blue:b1 + (b2 - b1) * t
-                         alpha:a1 + (a2 - a1) * t];
+- (UIColor *)colorAtGradientPosition:(CGFloat)position {
+  RGBAComponents rgba;
+  [self colorAtGradientPosition:position rgba:&rgba];
+  return [UIColor colorWithRed:rgba.r green:rgba.g blue:rgba.b alpha:rgba.a];
 }
 
 - (void)drawMapRect:(MKMapRect)mapRect
@@ -311,11 +340,15 @@
       CGFloat gradientStart = (drawStartDist - tailDist) / visibleLength;
       CGFloat gradientEnd = (drawEndDist - tailDist) / visibleLength;
 
-      UIColor *startColor = [self colorAtGradientPosition:gradientStart];
-      UIColor *endColor = [self colorAtGradientPosition:gradientEnd];
+      RGBAComponents startRGBA, endRGBA;
+      [self colorAtGradientPosition:gradientStart rgba:&startRGBA];
+      [self colorAtGradientPosition:gradientEnd rgba:&endRGBA];
 
-      NSArray *colors = @[(__bridge id)startColor.CGColor, (__bridge id)endColor.CGColor];
-      CGGradientRef gradient = CGGradientCreateWithColors(_colorSpace, (__bridge CFArrayRef)colors, NULL);
+      CGFloat components[] = {
+        startRGBA.r, startRGBA.g, startRGBA.b, startRGBA.a,
+        endRGBA.r, endRGBA.g, endRGBA.b, endRGBA.a
+      };
+      CGGradientRef gradient = CGGradientCreateWithColorComponents(_colorSpace, components, NULL, 2);
 
       CGContextSaveGState(context);
       CGContextBeginPath(context);
@@ -341,11 +374,15 @@
       CGFloat gradientStart = (CGFloat)i / segmentCount;
       CGFloat gradientEnd = (CGFloat)(i + 1) / segmentCount;
 
-      UIColor *startColor = [self colorAtGradientPosition:gradientStart];
-      UIColor *endColor = [self colorAtGradientPosition:gradientEnd];
+      RGBAComponents startRGBA, endRGBA;
+      [self colorAtGradientPosition:gradientStart rgba:&startRGBA];
+      [self colorAtGradientPosition:gradientEnd rgba:&endRGBA];
 
-      NSArray *colors = @[(__bridge id)startColor.CGColor, (__bridge id)endColor.CGColor];
-      CGGradientRef gradient = CGGradientCreateWithColors(_colorSpace, (__bridge CFArrayRef)colors, NULL);
+      CGFloat components[] = {
+        startRGBA.r, startRGBA.g, startRGBA.b, startRGBA.a,
+        endRGBA.r, endRGBA.g, endRGBA.b, endRGBA.a
+      };
+      CGGradientRef gradient = CGGradientCreateWithColorComponents(_colorSpace, components, NULL, 2);
 
       CGContextSaveGState(context);
       CGContextBeginPath(context);

--- a/ios/core/PolylineAnimatorBase.h
+++ b/ios/core/PolylineAnimatorBase.h
@@ -24,13 +24,22 @@
 
 @end
 
-@interface PolylineAnimatorBase : NSObject
+typedef struct {
+  CGFloat r, g, b, a;
+} RGBAComponents;
+
+@interface PolylineAnimatorBase : NSObject {
+@protected
+  RGBAComponents *_colorCache;
+  NSUInteger _colorCacheCount;
+}
 
 @property(nonatomic, strong) NSArray<CLLocation *> *coordinates;
 @property(nonatomic, strong) NSArray<UIColor *> *strokeColors;
 @property(nonatomic, strong) PolylineAnimatedOptions *animatedOptions;
 
 - (UIColor *)colorAtGradientPosition:(CGFloat)position;
+- (void)colorAtGradientPosition:(CGFloat)position rgba:(RGBAComponents *)out;
 - (CGFloat)applyEasing:(CGFloat)t;
 
 @end

--- a/ios/core/PolylineAnimatorBase.m
+++ b/ios/core/PolylineAnimatorBase.m
@@ -18,8 +18,34 @@
 - (instancetype)init {
   if (self = [super init]) {
     _animatedOptions = [PolylineAnimatedOptions defaultOptions];
+    _colorCache = NULL;
+    _colorCacheCount = 0;
   }
   return self;
+}
+
+- (void)dealloc {
+  free(_colorCache);
+}
+
+- (void)setStrokeColors:(NSArray<UIColor *> *)strokeColors {
+  _strokeColors = strokeColors;
+  [self rebuildColorCache];
+}
+
+- (void)rebuildColorCache {
+  free(_colorCache);
+  _colorCache = NULL;
+  _colorCacheCount = _strokeColors.count;
+  if (_colorCacheCount == 0) return;
+
+  _colorCache = (RGBAComponents *)malloc(sizeof(RGBAComponents) * _colorCacheCount);
+  for (NSUInteger i = 0; i < _colorCacheCount; i++) {
+    [_strokeColors[i] getRed:&_colorCache[i].r
+                       green:&_colorCache[i].g
+                        blue:&_colorCache[i].b
+                       alpha:&_colorCache[i].a];
+  }
 }
 
 - (CGFloat)applyEasing:(CGFloat)t {
@@ -35,34 +61,38 @@
   return t;
 }
 
-- (UIColor *)colorAtGradientPosition:(CGFloat)position {
-  if (!_strokeColors || _strokeColors.count == 0) {
-    return [UIColor blackColor];
+- (void)colorAtGradientPosition:(CGFloat)position rgba:(RGBAComponents *)out {
+  if (_colorCacheCount == 0) {
+    *out = (RGBAComponents){0, 0, 0, 1};
+    return;
   }
-  if (_strokeColors.count == 1) {
-    return _strokeColors[0];
+  if (_colorCacheCount == 1) {
+    *out = _colorCache[0];
+    return;
   }
 
   position = MAX(0, MIN(1, position));
-  CGFloat scaledPos = position * (_strokeColors.count - 1);
-  NSUInteger index = (NSUInteger)floor(scaledPos);
+  CGFloat scaledPos = position * (_colorCacheCount - 1);
+  NSUInteger index = (NSUInteger)scaledPos;
   CGFloat t = scaledPos - index;
 
-  if (index >= _strokeColors.count - 1) {
-    return _strokeColors.lastObject;
+  if (index >= _colorCacheCount - 1) {
+    *out = _colorCache[_colorCacheCount - 1];
+    return;
   }
 
-  UIColor *c1 = _strokeColors[index];
-  UIColor *c2 = _strokeColors[index + 1];
+  RGBAComponents c1 = _colorCache[index];
+  RGBAComponents c2 = _colorCache[index + 1];
+  out->r = c1.r + (c2.r - c1.r) * t;
+  out->g = c1.g + (c2.g - c1.g) * t;
+  out->b = c1.b + (c2.b - c1.b) * t;
+  out->a = c1.a + (c2.a - c1.a) * t;
+}
 
-  CGFloat r1, g1, b1, a1, r2, g2, b2, a2;
-  [c1 getRed:&r1 green:&g1 blue:&b1 alpha:&a1];
-  [c2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
-
-  return [UIColor colorWithRed:r1 + (r2 - r1) * t
-                         green:g1 + (g2 - g1) * t
-                          blue:b1 + (b2 - b1) * t
-                         alpha:a1 + (a2 - a1) * t];
+- (UIColor *)colorAtGradientPosition:(CGFloat)position {
+  RGBAComponents rgba;
+  [self colorAtGradientPosition:position rgba:&rgba];
+  return [UIColor colorWithRed:rgba.r green:rgba.g blue:rgba.b alpha:rgba.a];
 }
 
 @end

--- a/src/components/Marker.tsx
+++ b/src/components/Marker.tsx
@@ -52,7 +52,19 @@ export interface MarkerProps {
   children?: ReactNode;
 }
 
-export class Marker extends React.Component<MarkerProps> {
+export class Marker extends React.PureComponent<MarkerProps> {
+  private getStyle(zIndex: number | undefined) {
+    if (zIndex == null) return styles.marker;
+    if (zIndex !== this._cachedZIndex) {
+      this._cachedZIndex = zIndex;
+      this._cachedStyle = [{ zIndex }, styles.marker];
+    }
+    return this._cachedStyle!;
+  }
+
+  private _cachedZIndex: number | undefined;
+  private _cachedStyle: any;
+
   render() {
     const {
       name,
@@ -69,7 +81,7 @@ export class Marker extends React.Component<MarkerProps> {
 
     return (
       <LuggMarkerViewNativeComponent
-        style={[{ zIndex }, styles.marker]}
+        style={this.getStyle(zIndex)}
         name={name}
         coordinate={coordinate}
         title={title}

--- a/src/components/Polyline.tsx
+++ b/src/components/Polyline.tsx
@@ -57,7 +57,19 @@ export interface PolylineProps {
   zIndex?: number;
 }
 
-export class Polyline extends React.Component<PolylineProps> {
+export class Polyline extends React.PureComponent<PolylineProps> {
+  private getStyle(zIndex: number | undefined) {
+    if (zIndex == null) return styles.polyline;
+    if (zIndex !== this._cachedZIndex) {
+      this._cachedZIndex = zIndex;
+      this._cachedStyle = [{ zIndex }, styles.polyline];
+    }
+    return this._cachedStyle!;
+  }
+
+  private _cachedZIndex: number | undefined;
+  private _cachedStyle: any;
+
   render() {
     const {
       coordinates,
@@ -70,7 +82,7 @@ export class Polyline extends React.Component<PolylineProps> {
 
     return (
       <LuggPolylineViewNativeComponent
-        style={[{ zIndex }, styles.polyline]}
+        style={this.getStyle(zIndex)}
         coordinates={coordinates}
         strokeColors={strokeColors}
         strokeWidth={strokeWidth}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,8 @@
-export * from './Marker';
-export * from './Polyline';
+export { Marker } from './Marker';
+export type { MarkerProps } from './Marker';
+export { Polyline } from './Polyline';
+export type {
+  PolylineProps,
+  PolylineEasing,
+  PolylineAnimatedOptions,
+} from './Polyline';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,14 @@
 export { MapView } from './MapView';
 export { MapProvider } from './MapProvider';
 export type { MapProviderProps } from './MapProvider.types';
-export * from './components';
+export { Marker } from './components';
+export type { MarkerProps } from './components';
+export { Polyline } from './components';
+export type {
+  PolylineProps,
+  PolylineEasing,
+  PolylineAnimatedOptions,
+} from './components';
 export type {
   MapViewProps,
   MapViewRef,

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -1,7 +1,10 @@
 export { MapView } from './MapView.web';
 export { MapProvider } from './MapProvider.web';
 export type { MapProviderProps } from './MapProvider.types';
-export * from './components/index.web';
+export { Marker } from './components/index.web';
+export type { MarkerProps } from './components/index.web';
+export { Polyline } from './components/index.web';
+export type { PolylineProps } from './components/index.web';
 export type {
   MapViewProps,
   MapViewRef,


### PR DESCRIPTION
## Summary

Performance audit fixes across iOS native, Android native, and TypeScript layers.

- **iOS**: Cache RGBA components in polyline animators (`PolylineAnimatorBase`, `MKPolylineAnimator`) to avoid `getRed:green:blue:alpha:` + UIColor allocation per-frame during gradient animations
- **Android**: Unregister camera listeners (`OnCameraMoveStarted`, `OnCameraMove`, `OnCameraIdle`) before `destroy()` in `GoogleMapProvider` to prevent post-destroy callbacks and memory leaks
- **JS**: Convert `Marker` and `Polyline` from `Component` to `PureComponent` with memoized zIndex styles to prevent unnecessary re-renders and native view updates
- **JS**: Replace barrel `export *` with explicit named exports for better tree-shaking

## Type of Change

- [x] Bug fix

## Test Plan

- Verified TypeScript typechecks pass
- Lint and commitlint pass via lefthook

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)