### PR TITLE
refactor: prop diffing and rename myLocationButtonEnabled

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggMapView.kt
+++ b/android/src/main/java/com/luggmaps/LuggMapView.kt
@@ -50,7 +50,7 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
   private var rotateEnabled: Boolean = true
   private var pitchEnabled: Boolean = true
   private var userLocationEnabled: Boolean = false
-  private var myLocationButtonEnabled: Boolean = false
+  private var userLocationButtonEnabled: Boolean = false
   private var minZoom: Double? = null
   private var maxZoom: Double? = null
   private var edgeInsets: EdgeInsets = EdgeInsets()
@@ -148,7 +148,7 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
     provider?.setRotateEnabled(rotateEnabled)
     provider?.setPitchEnabled(pitchEnabled)
     provider?.setUserLocationEnabled(userLocationEnabled)
-    provider?.setMyLocationButtonEnabled(myLocationButtonEnabled)
+    provider?.setUserLocationButtonEnabled(userLocationButtonEnabled)
     provider?.setTheme(theme)
     minZoom?.let { provider?.setMinZoom(it) }
     maxZoom?.let { provider?.setMaxZoom(it) }
@@ -176,46 +176,55 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
   }
 
   fun setZoomEnabled(enabled: Boolean) {
+    if (zoomEnabled == enabled) return
     zoomEnabled = enabled
     provider?.setZoomEnabled(enabled)
   }
 
   fun setScrollEnabled(enabled: Boolean) {
+    if (scrollEnabled == enabled) return
     scrollEnabled = enabled
     provider?.setScrollEnabled(enabled)
   }
 
   fun setRotateEnabled(enabled: Boolean) {
+    if (rotateEnabled == enabled) return
     rotateEnabled = enabled
     provider?.setRotateEnabled(enabled)
   }
 
   fun setPitchEnabled(enabled: Boolean) {
+    if (pitchEnabled == enabled) return
     pitchEnabled = enabled
     provider?.setPitchEnabled(enabled)
   }
 
   fun setUserLocationEnabled(enabled: Boolean) {
+    if (userLocationEnabled == enabled) return
     userLocationEnabled = enabled
     provider?.setUserLocationEnabled(enabled)
   }
 
-  fun setMyLocationButtonEnabled(enabled: Boolean) {
-    myLocationButtonEnabled = enabled
-    provider?.setMyLocationButtonEnabled(enabled)
+  fun setUserLocationButtonEnabled(enabled: Boolean) {
+    if (userLocationButtonEnabled == enabled) return
+    userLocationButtonEnabled = enabled
+    provider?.setUserLocationButtonEnabled(enabled)
   }
 
   fun setMinZoom(zoom: Double) {
+    if (minZoom == zoom) return
     minZoom = zoom
     provider?.setMinZoom(zoom)
   }
 
   fun setMaxZoom(zoom: Double) {
+    if (maxZoom == zoom) return
     maxZoom = zoom
     provider?.setMaxZoom(zoom)
   }
 
   fun setTheme(value: String) {
+    if (theme == value) return
     theme = value
     provider?.setTheme(value)
   }
@@ -227,7 +236,9 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
     right: Int,
     duration: Int = 0
   ) {
-    edgeInsets = EdgeInsets(top, left, bottom, right)
+    val newEdgeInsets = EdgeInsets(top, left, bottom, right)
+    if (edgeInsets == newEdgeInsets) return
+    edgeInsets = newEdgeInsets
     provider?.setEdgeInsets(edgeInsets, duration)
   }
 

--- a/android/src/main/java/com/luggmaps/LuggMapViewManager.kt
+++ b/android/src/main/java/com/luggmaps/LuggMapViewManager.kt
@@ -113,9 +113,9 @@ class LuggMapViewManager :
     view.setUserLocationEnabled(value)
   }
 
-  @ReactProp(name = "myLocationButtonEnabled", defaultBoolean = false)
-  override fun setMyLocationButtonEnabled(view: LuggMapView, value: Boolean) {
-    view.setMyLocationButtonEnabled(value)
+  @ReactProp(name = "userLocationButtonEnabled", defaultBoolean = false)
+  override fun setUserLocationButtonEnabled(view: LuggMapView, value: Boolean) {
+    view.setUserLocationButtonEnabled(value)
   }
 
   @ReactProp(name = "minZoom")

--- a/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
+++ b/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
@@ -53,7 +53,7 @@ class GoogleMapProvider(private val context: Context) :
   private var rotateEnabled: Boolean = true
   private var pitchEnabled: Boolean = true
   private var userLocationEnabled: Boolean = false
-  private var myLocationButtonEnabled: Boolean = false
+  private var userLocationButtonEnabled: Boolean = false
 
   // Zoom limits
   private var minZoom: Float? = null
@@ -184,8 +184,8 @@ class GoogleMapProvider(private val context: Context) :
     googleMap?.isMyLocationEnabled = userLocationEnabled && hasPermission
   }
 
-  override fun setMyLocationButtonEnabled(enabled: Boolean) {
-    myLocationButtonEnabled = enabled
+  override fun setUserLocationButtonEnabled(enabled: Boolean) {
+    userLocationButtonEnabled = enabled
     googleMap?.uiSettings?.isMyLocationButtonEnabled = enabled
   }
 
@@ -481,6 +481,7 @@ class GoogleMapProvider(private val context: Context) :
       isScrollGesturesEnabled = scrollEnabled
       isRotateGesturesEnabled = rotateEnabled
       isTiltGesturesEnabled = pitchEnabled
+      isMyLocationButtonEnabled = userLocationButtonEnabled
     }
   }
 
@@ -513,7 +514,7 @@ class GoogleMapProvider(private val context: Context) :
         context.checkSelfPermission(android.Manifest.permission.ACCESS_COARSE_LOCATION) ==
         android.content.pm.PackageManager.PERMISSION_GRANTED
     googleMap?.isMyLocationEnabled = userLocationEnabled && hasPermission
-    googleMap?.uiSettings?.isMyLocationButtonEnabled = myLocationButtonEnabled
+    googleMap?.uiSettings?.isMyLocationButtonEnabled = userLocationButtonEnabled
   }
 
   // endregion

--- a/android/src/main/java/com/luggmaps/core/MapProviderDelegate.kt
+++ b/android/src/main/java/com/luggmaps/core/MapProviderDelegate.kt
@@ -25,7 +25,7 @@ interface MapProvider {
   fun setRotateEnabled(enabled: Boolean)
   fun setPitchEnabled(enabled: Boolean)
   fun setUserLocationEnabled(enabled: Boolean)
-  fun setMyLocationButtonEnabled(enabled: Boolean)
+  fun setUserLocationButtonEnabled(enabled: Boolean)
   fun setTheme(value: String)
   fun setMinZoom(zoom: Double)
   fun setMaxZoom(zoom: Double)

--- a/docs/MAPVIEW.md
+++ b/docs/MAPVIEW.md
@@ -32,6 +32,8 @@ import { MapView } from '@lugg/maps';
 | `rotateEnabled` | `boolean` | `true` | Enable rotation gestures |
 | `pitchEnabled` | `boolean` | `true` | Enable pitch/tilt gestures |
 | `edgeInsets` | `EdgeInsets` | - | Map content edge insets |
+| `userLocationEnabled` | `boolean` | `false` | Show current user location on the map |
+| `userLocationButtonEnabled` | `boolean` | `false` | Show native my-location button (Android only) |
 | `theme` | `'light' \| 'dark' \| 'system'` | `'system'` | Map color theme |
 | `onCameraMove` | `(event) => void` | - | Called when camera moves |
 | `onCameraIdle` | `(event) => void` | - | Called when camera stops moving |

--- a/ios/LuggMapView.mm
+++ b/ios/LuggMapView.mm
@@ -207,6 +207,8 @@ using namespace luggmaps::events;
            oldProps:(Props::Shared const &)oldProps {
   const auto &newViewProps =
       *std::static_pointer_cast<LuggMapViewProps const>(props);
+  const auto &prevViewProps =
+      *std::static_pointer_cast<LuggMapViewProps const>(_props);
 
   _providerType = newViewProps.provider;
 
@@ -216,34 +218,49 @@ using namespace luggmaps::events;
     _mapId = newMapId;
   }
 
-  _zoomEnabled = newViewProps.zoomEnabled;
-  _scrollEnabled = newViewProps.scrollEnabled;
-  _rotateEnabled = newViewProps.rotateEnabled;
-  _pitchEnabled = newViewProps.pitchEnabled;
-  _userLocationEnabled = newViewProps.userLocationEnabled;
-  _minZoom = newViewProps.minZoom;
-  _maxZoom = newViewProps.maxZoom;
+  if (newViewProps.zoomEnabled != prevViewProps.zoomEnabled) {
+    _zoomEnabled = newViewProps.zoomEnabled;
+    [_provider setZoomEnabled:_zoomEnabled];
+  }
+  if (newViewProps.scrollEnabled != prevViewProps.scrollEnabled) {
+    _scrollEnabled = newViewProps.scrollEnabled;
+    [_provider setScrollEnabled:_scrollEnabled];
+  }
+  if (newViewProps.rotateEnabled != prevViewProps.rotateEnabled) {
+    _rotateEnabled = newViewProps.rotateEnabled;
+    [_provider setRotateEnabled:_rotateEnabled];
+  }
+  if (newViewProps.pitchEnabled != prevViewProps.pitchEnabled) {
+    _pitchEnabled = newViewProps.pitchEnabled;
+    [_provider setPitchEnabled:_pitchEnabled];
+  }
+  if (newViewProps.userLocationEnabled != prevViewProps.userLocationEnabled) {
+    _userLocationEnabled = newViewProps.userLocationEnabled;
+    [_provider setUserLocationEnabled:_userLocationEnabled];
+  }
+  if (newViewProps.minZoom != prevViewProps.minZoom) {
+    _minZoom = newViewProps.minZoom;
+    [_provider setMinZoom:_minZoom];
+  }
+  if (newViewProps.maxZoom != prevViewProps.maxZoom) {
+    _maxZoom = newViewProps.maxZoom;
+    [_provider setMaxZoom:_maxZoom];
+  }
+  if (newViewProps.theme != prevViewProps.theme) {
+    _theme = newViewProps.theme;
+    [_provider setTheme:(NSInteger)_theme];
+  }
 
-  _theme = newViewProps.theme;
-
-  _oldEdgeInsets = _edgeInsets;
-  _edgeInsets = UIEdgeInsetsMake(
+  UIEdgeInsets newEdgeInsets = UIEdgeInsetsMake(
       newViewProps.edgeInsets.top, newViewProps.edgeInsets.left,
       newViewProps.edgeInsets.bottom, newViewProps.edgeInsets.right);
-
-  [super updateProps:props oldProps:oldProps];
-}
-
-- (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask {
-  [super finalizeUpdates:updateMask];
-
-  if (updateMask & RNComponentViewUpdateMaskProps) {
-    if (!_provider)
-      return;
-
-    [self applyProps];
+  if (!UIEdgeInsetsEqualToEdgeInsets(newEdgeInsets, _edgeInsets)) {
+    _oldEdgeInsets = _edgeInsets;
+    _edgeInsets = newEdgeInsets;
     [_provider setEdgeInsets:_edgeInsets oldEdgeInsets:_oldEdgeInsets];
   }
+
+  [super updateProps:props oldProps:oldProps];
 }
 
 #pragma mark - Commands

--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -91,7 +91,7 @@ export class MapView
       pitchEnabled,
       edgeInsets,
       userLocationEnabled,
-      myLocationButtonEnabled,
+      userLocationButtonEnabled,
       theme,
       onCameraMove,
       onCameraIdle,
@@ -116,7 +116,7 @@ export class MapView
         pitchEnabled={pitchEnabled}
         edgeInsets={edgeInsets}
         userLocationEnabled={userLocationEnabled}
-        myLocationButtonEnabled={myLocationButtonEnabled}
+        userLocationButtonEnabled={userLocationButtonEnabled}
         theme={theme}
         onCameraMove={onCameraMove}
         onCameraIdle={onCameraIdle}

--- a/src/MapView.types.ts
+++ b/src/MapView.types.ts
@@ -111,7 +111,7 @@ export interface MapViewProps extends ViewProps {
    * @default false
    * @platform android
    */
-  myLocationButtonEnabled?: boolean;
+  userLocationButtonEnabled?: boolean;
   /**
    * Map color theme
    * @default 'system'

--- a/src/fabric/LuggMapViewNativeComponent.ts
+++ b/src/fabric/LuggMapViewNativeComponent.ts
@@ -51,7 +51,7 @@ export interface NativeProps extends ViewProps {
   pitchEnabled?: boolean;
   edgeInsets?: EdgeInsets;
   userLocationEnabled?: boolean;
-  myLocationButtonEnabled?: boolean;
+  userLocationButtonEnabled?: boolean;
   theme?: WithDefault<'light' | 'dark' | 'system', 'system'>;
   onCameraMove?: DirectEventHandler<CameraMoveEvent>;
   onCameraIdle?: DirectEventHandler<CameraIdleEvent>;


### PR DESCRIPTION
## Summary

Diff cached props before applying to the map provider on both iOS and Android, avoiding unnecessary native calls when values haven't changed. Also renames `myLocationButtonEnabled` to `userLocationButtonEnabled` for consistency with `userLocationEnabled`.

## Type of Change

- [x] Bug fix
- [x] Breaking change

## Test Plan

Build and verify props are only applied when changed. Verify `userLocationButtonEnabled` works on Android.

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)