### PR TITLE
fix: default marker anchor to bottom-center

### DIFF
--- a/docs/MARKER.md
+++ b/docs/MARKER.md
@@ -34,7 +34,7 @@ import { MapView, Marker } from '@lugg/maps';
 | `coordinate` | `Coordinate` | **required** | Marker position |
 | `title` | `string` | - | Callout title |
 | `description` | `string` | - | Callout description |
-| `anchor` | `Point` | - | Anchor point for custom views |
+| `anchor` | `Point` | `{x: 0.5, y: 1}` | Anchor point for custom views |
 | `zIndex` | `number` | - | Z-index for marker ordering. Higher values render on top |
 | `rotate` | `number` | `0` | Rotation angle in degrees clockwise from north |
 | `scale` | `number` | `1` | Scale factor for the marker |
@@ -83,7 +83,7 @@ Use the `children` prop to render a custom marker view. The `anchor` prop contro
 - `{ x: 0.5, y: 0 }` - top center
 - `{ x: 1, y: 0 }` - top right
 - `{ x: 0.5, y: 0.5 }` - center
-- `{ x: 0.5, y: 1 }` - bottom center (default for pins)
+- `{ x: 0.5, y: 1 }` - bottom center **(default)**
 
 ## Callout
 

--- a/example/shared/src/markers.ts
+++ b/example/shared/src/markers.ts
@@ -33,7 +33,6 @@ export const INITIAL_MARKERS: MarkerData[] = [
     name: 'marker-4',
     coordinate: { latitude: 37.775, longitude: -122.44 },
     type: 'basic',
-    anchor: { x: 0.5, y: 1 },
   },
   {
     id: '7',
@@ -63,7 +62,6 @@ export const INITIAL_MARKERS: MarkerData[] = [
     name: 'marker-2',
     coordinate: { latitude: 37.785, longitude: -122.42 },
     type: 'basic',
-    anchor: { x: 0.5, y: 1 },
   },
   {
     id: '9',
@@ -91,6 +89,5 @@ export const INITIAL_MARKERS: MarkerData[] = [
     name: 'marker-5',
     coordinate: { latitude: 37.79, longitude: -122.435 },
     type: 'basic',
-    anchor: { x: 0.5, y: 1 },
   },
 ];

--- a/src/components/Marker.tsx
+++ b/src/components/Marker.tsx
@@ -3,6 +3,7 @@ import { StyleSheet } from 'react-native';
 import LuggMarkerViewNativeComponent from '../fabric/LuggMarkerViewNativeComponent';
 import LuggCalloutViewNativeComponent from '../fabric/LuggCalloutViewNativeComponent';
 import type { MarkerProps } from './Marker.types';
+import type { Point } from '../types';
 
 export type {
   CalloutOptions,
@@ -10,6 +11,8 @@ export type {
   MarkerPressEvent,
   MarkerDragEvent,
 } from './Marker.types';
+
+const DEFAULT_ANCHOR: Point = { x: 0.5, y: 1 };
 
 export class Marker extends React.PureComponent<MarkerProps> {
   private getStyle(zIndex: number | undefined) {
@@ -60,7 +63,7 @@ export class Marker extends React.PureComponent<MarkerProps> {
         coordinate={coordinate}
         title={title}
         description={description}
-        anchor={anchor}
+        anchor={anchor ?? DEFAULT_ANCHOR}
         rotate={rotate}
         scale={scale}
         rasterize={rasterize}

--- a/src/components/Marker.types.ts
+++ b/src/components/Marker.types.ts
@@ -41,7 +41,10 @@ export interface MarkerProps {
    */
   description?: string;
   /**
-   * Anchor point for custom marker views
+   * Anchor point for custom marker views.
+   * `{x: 0.5, y: 1}` places the bottom-center of the marker at the coordinate.
+   *
+   * @default {x: 0.5, y: 1}
    */
   anchor?: Point;
   /**


### PR DESCRIPTION
## Summary

- Marker `anchor` defaults to `{x: 0.5, y: 1}` (bottom-center) at the JS level, preventing codegen's `{0, 0}` struct default from overriding the intended native default
- Updated jsdoc and docs to document the default value

## Type of Change

- [x] Bug fix

## Test Plan

- Render markers with custom views without specifying `anchor` — should pin at bottom-center
- Render markers with explicit `anchor` — should respect the provided value

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)