### PR TITLE
feat: add poiEnabled and poiFilter props to MapView

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggMapView.kt
+++ b/android/src/main/java/com/luggmaps/LuggMapView.kt
@@ -66,6 +66,9 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
   private var pitchEnabled: Boolean = true
   private var userLocationEnabled: Boolean = false
   private var userLocationButtonEnabled: Boolean = false
+  private var poiEnabled: Boolean = true
+  private var poiFilterMode: String = "including"
+  private var poiFilterCategories: List<String> = emptyList()
   private var minZoom: Double? = null
   private var maxZoom: Double? = null
   private var edgeInsets: EdgeInsets = EdgeInsets()
@@ -189,6 +192,9 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
     minZoom?.let { provider?.setMinZoom(it) }
     maxZoom?.let { provider?.setMaxZoom(it) }
     provider?.setEdgeInsets(edgeInsets)
+    provider?.setPoiEnabled(poiEnabled)
+    provider?.setPoiFilterMode(poiFilterMode)
+    provider?.setPoiFilterCategories(poiFilterCategories)
   }
 
   fun setProvider(value: String?) {
@@ -269,6 +275,24 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
     if (theme == value) return
     theme = value
     provider?.setTheme(value)
+  }
+
+  fun setPoiEnabled(enabled: Boolean) {
+    if (poiEnabled == enabled) return
+    poiEnabled = enabled
+    provider?.setPoiEnabled(enabled)
+  }
+
+  fun setPoiFilterMode(value: String) {
+    if (poiFilterMode == value) return
+    poiFilterMode = value
+    provider?.setPoiFilterMode(value)
+  }
+
+  fun setPoiFilterCategories(categories: List<String>) {
+    if (poiFilterCategories == categories) return
+    poiFilterCategories = categories
+    provider?.setPoiFilterCategories(categories)
   }
 
   fun setEdgeInsets(

--- a/android/src/main/java/com/luggmaps/LuggMapViewManager.kt
+++ b/android/src/main/java/com/luggmaps/LuggMapViewManager.kt
@@ -162,6 +162,27 @@ class LuggMapViewManager :
     view.setTheme(value ?: "system")
   }
 
+  @ReactProp(name = "poiEnabled", defaultBoolean = true)
+  override fun setPoiEnabled(view: LuggMapView, value: Boolean) {
+    view.setPoiEnabled(value)
+  }
+
+  @ReactProp(name = "poiFilterMode")
+  override fun setPoiFilterMode(view: LuggMapView, value: String?) {
+    view.setPoiFilterMode(value ?: "including")
+  }
+
+  @ReactProp(name = "poiFilterCategories")
+  override fun setPoiFilterCategories(view: LuggMapView, value: ReadableArray?) {
+    val categories = mutableListOf<String>()
+    value?.let { array ->
+      for (i in 0 until array.size()) {
+        array.getString(i)?.let { categories.add(it) }
+      }
+    }
+    view.setPoiFilterCategories(categories)
+  }
+
   @ReactProp(name = "edgeInsets")
   override fun setEdgeInsets(view: LuggMapView, value: ReadableMap?) {
     value?.let {

--- a/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
+++ b/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
@@ -510,6 +510,12 @@ class GoogleMapProvider(private val context: Context) :
     }
   }
 
+  override fun setPoiEnabled(enabled: Boolean) {}
+
+  override fun setPoiFilterMode(mode: String) {}
+
+  override fun setPoiFilterCategories(categories: List<String>) {}
+
   // endregion
 
   // region MarkerViewDelegate

--- a/android/src/main/java/com/luggmaps/core/MapProviderDelegate.kt
+++ b/android/src/main/java/com/luggmaps/core/MapProviderDelegate.kt
@@ -38,6 +38,9 @@ interface MapProvider {
   fun setMaxZoom(zoom: Double)
   fun setEdgeInsets(edgeInsets: EdgeInsets)
   fun setEdgeInsets(edgeInsets: EdgeInsets, duration: Int)
+  fun setPoiEnabled(enabled: Boolean)
+  fun setPoiFilterMode(mode: String)
+  fun setPoiFilterCategories(categories: List<String>)
 
   // Children
   fun addMarkerView(markerView: LuggMarkerView)

--- a/docs/MAPVIEW.md
+++ b/docs/MAPVIEW.md
@@ -35,6 +35,8 @@ import { MapView } from '@lugg/maps';
 | `edgeInsets` | `EdgeInsets` | - | Map content edge insets |
 | `userLocationEnabled` | `boolean` | `false` | Show current user location on the map |
 | `userLocationButtonEnabled` | `boolean` | `false` | Show native my-location button (Android only) |
+| `poiEnabled` | `boolean` | `true` | Show points of interest (Apple Maps only) |
+| `poiFilter` | [`PoiFilter`](#poifilter) | - | Filter POI categories (Apple Maps only) |
 | `theme` | [`MapTheme`](#maptheme) | `'system'` | Map color theme |
 | `onPress` | `(event: MapPressEvent) => void` | - | Called when the map is pressed |
 | `onLongPress` | `(event: MapPressEvent) => void` | - | Called when the map is long pressed |
@@ -68,6 +70,62 @@ import { MapView } from '@lugg/maps';
 | `'light'` | Light appearance |
 | `'dark'` | Dark appearance |
 | `'system'` | Follow system appearance |
+
+### PoiFilter
+
+```ts
+interface PoiFilter {
+  mode?: 'including' | 'excluding'; // default: 'including'
+  categories: PoiCategory[];
+}
+```
+
+When `mode` is `'including'`, only the specified categories are shown. When `'excluding'`, all categories are shown except the specified ones.
+
+### PoiCategory
+
+| Value | Description |
+|-------|-------------|
+| `'airport'` | Airports |
+| `'amusement-park'` | Amusement parks |
+| `'aquarium'` | Aquariums |
+| `'atm'` | ATMs |
+| `'bakery'` | Bakeries |
+| `'bank'` | Banks |
+| `'beach'` | Beaches |
+| `'brewery'` | Breweries |
+| `'cafe'` | Cafes |
+| `'campground'` | Campgrounds |
+| `'car-rental'` | Car rental locations |
+| `'ev-charger'` | EV charging stations |
+| `'fire-station'` | Fire stations |
+| `'fitness-center'` | Fitness centers |
+| `'food-market'` | Food markets |
+| `'gas-station'` | Gas stations |
+| `'hospital'` | Hospitals |
+| `'hotel'` | Hotels |
+| `'laundry'` | Laundry services |
+| `'library'` | Libraries |
+| `'marina'` | Marinas |
+| `'movie-theater'` | Movie theaters |
+| `'museum'` | Museums |
+| `'national-park'` | National parks |
+| `'nightlife'` | Nightlife venues |
+| `'park'` | Parks |
+| `'parking'` | Parking lots |
+| `'pharmacy'` | Pharmacies |
+| `'police'` | Police stations |
+| `'post-office'` | Post offices |
+| `'public-transport'` | Public transport stations |
+| `'restaurant'` | Restaurants |
+| `'restroom'` | Restrooms |
+| `'school'` | Schools |
+| `'stadium'` | Stadiums |
+| `'store'` | Stores |
+| `'theater'` | Theaters |
+| `'university'` | Universities |
+| `'winery'` | Wineries |
+| `'zoo'` | Zoos |
 
 ## Ref Methods
 

--- a/ios/LuggMapView.mm
+++ b/ios/LuggMapView.mm
@@ -42,6 +42,9 @@ using namespace luggmaps::events;
   BOOL _userLocationEnabled;
   LuggMapViewMapType _mapType;
   LuggMapViewTheme _theme;
+  BOOL _poiEnabled;
+  LuggMapViewPoiFilterMode _poiFilterMode;
+  NSArray<NSString *> *_poiFilterCategories;
   double _minZoom;
   double _maxZoom;
   UIEdgeInsets _edgeInsets;
@@ -65,6 +68,9 @@ using namespace luggmaps::events;
     _rotateEnabled = YES;
     _pitchEnabled = YES;
     _userLocationEnabled = NO;
+    _poiEnabled = NO;
+    _poiFilterMode = LuggMapViewPoiFilterMode::Including;
+    _poiFilterCategories = @[];
     _mapType = LuggMapViewMapType::Standard;
     _theme = LuggMapViewTheme::System;
     _edgeInsets = UIEdgeInsetsZero;
@@ -276,6 +282,9 @@ using namespace luggmaps::events;
   [_provider setUserLocationEnabled:_userLocationEnabled];
   [_provider setMapType:_mapType];
   [_provider setTheme:_theme];
+  [_provider setPoiEnabled:_poiEnabled];
+  [_provider setPoiFilterMode:_poiFilterMode];
+  [_provider setPoiFilterCategories:_poiFilterCategories];
   [_provider setMinZoom:_minZoom];
   [_provider setMaxZoom:_maxZoom];
 }
@@ -314,6 +323,22 @@ using namespace luggmaps::events;
   if (newViewProps.userLocationEnabled != prevViewProps.userLocationEnabled) {
     _userLocationEnabled = newViewProps.userLocationEnabled;
     [_provider setUserLocationEnabled:_userLocationEnabled];
+  }
+  if (newViewProps.poiEnabled != prevViewProps.poiEnabled) {
+    _poiEnabled = newViewProps.poiEnabled;
+    [_provider setPoiEnabled:_poiEnabled];
+  }
+  if (newViewProps.poiFilterMode != prevViewProps.poiFilterMode) {
+    _poiFilterMode = newViewProps.poiFilterMode;
+    [_provider setPoiFilterMode:_poiFilterMode];
+  }
+  if (newViewProps.poiFilterCategories != prevViewProps.poiFilterCategories) {
+    NSMutableArray<NSString *> *categories = [NSMutableArray array];
+    for (const auto &category : newViewProps.poiFilterCategories) {
+      [categories addObject:[NSString stringWithUTF8String:category.c_str()]];
+    }
+    _poiFilterCategories = [categories copy];
+    [_provider setPoiFilterCategories:_poiFilterCategories];
   }
   if (newViewProps.mapType != prevViewProps.mapType) {
     _mapType = newViewProps.mapType;

--- a/ios/core/AppleMapProvider.mm
+++ b/ios/core/AppleMapProvider.mm
@@ -1,6 +1,7 @@
 #import "AppleMapProvider.h"
 
 using facebook::react::LuggMapViewMapType;
+using facebook::react::LuggMapViewPoiFilterMode;
 using facebook::react::LuggMapViewTheme;
 
 #import "../LuggCalloutView.h"
@@ -136,6 +137,9 @@ static double tileToLng(NSInteger x, NSInteger z) {
   UIEdgeInsets _edgeInsetsTo;
   CFTimeInterval _edgeInsetsAnimationStart;
   CFTimeInterval _edgeInsetsAnimationDuration;
+  BOOL _poiEnabled;
+  LuggMapViewPoiFilterMode _poiFilterMode;
+  NSArray<NSString *> *_poiFilterCategories;
 }
 
 @synthesize delegate = _delegate;
@@ -147,6 +151,9 @@ static double tileToLng(NSInteger x, NSInteger z) {
     _overlayToCircleMap = [NSMapTable strongToWeakObjectsMapTable];
     _overlayToGroundOverlayMap = [NSMapTable strongToWeakObjectsMapTable];
     _overlayToTileOverlayMap = [NSMapTable strongToWeakObjectsMapTable];
+    _poiEnabled = YES;
+    _poiFilterMode = LuggMapViewPoiFilterMode::Including;
+    _poiFilterCategories = @[];
   }
   return self;
 }
@@ -238,6 +245,98 @@ static double tileToLng(NSInteger x, NSInteger z) {
 
 - (void)setUserLocationEnabled:(BOOL)enabled {
   _mapView.showsUserLocation = enabled;
+}
+
+static MKPointOfInterestCategory poiCategoryFromString(NSString *string) {
+  static NSDictionary<NSString *, MKPointOfInterestCategory> *map;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    map = @{
+      @"airport" : MKPointOfInterestCategoryAirport,
+      @"amusement-park" : MKPointOfInterestCategoryAmusementPark,
+      @"aquarium" : MKPointOfInterestCategoryAquarium,
+      @"atm" : MKPointOfInterestCategoryATM,
+      @"bakery" : MKPointOfInterestCategoryBakery,
+      @"bank" : MKPointOfInterestCategoryBank,
+      @"beach" : MKPointOfInterestCategoryBeach,
+      @"brewery" : MKPointOfInterestCategoryBrewery,
+      @"cafe" : MKPointOfInterestCategoryCafe,
+      @"campground" : MKPointOfInterestCategoryCampground,
+      @"car-rental" : MKPointOfInterestCategoryCarRental,
+      @"ev-charger" : MKPointOfInterestCategoryEVCharger,
+      @"fire-station" : MKPointOfInterestCategoryFireStation,
+      @"fitness-center" : MKPointOfInterestCategoryFitnessCenter,
+      @"food-market" : MKPointOfInterestCategoryFoodMarket,
+      @"gas-station" : MKPointOfInterestCategoryGasStation,
+      @"hospital" : MKPointOfInterestCategoryHospital,
+      @"hotel" : MKPointOfInterestCategoryHotel,
+      @"laundry" : MKPointOfInterestCategoryLaundry,
+      @"library" : MKPointOfInterestCategoryLibrary,
+      @"marina" : MKPointOfInterestCategoryMarina,
+      @"movie-theater" : MKPointOfInterestCategoryMovieTheater,
+      @"museum" : MKPointOfInterestCategoryMuseum,
+      @"national-park" : MKPointOfInterestCategoryNationalPark,
+      @"nightlife" : MKPointOfInterestCategoryNightlife,
+      @"park" : MKPointOfInterestCategoryPark,
+      @"parking" : MKPointOfInterestCategoryParking,
+      @"pharmacy" : MKPointOfInterestCategoryPharmacy,
+      @"police" : MKPointOfInterestCategoryPolice,
+      @"post-office" : MKPointOfInterestCategoryPostOffice,
+      @"public-transport" : MKPointOfInterestCategoryPublicTransport,
+      @"restaurant" : MKPointOfInterestCategoryRestaurant,
+      @"restroom" : MKPointOfInterestCategoryRestroom,
+      @"school" : MKPointOfInterestCategorySchool,
+      @"stadium" : MKPointOfInterestCategoryStadium,
+      @"store" : MKPointOfInterestCategoryStore,
+      @"theater" : MKPointOfInterestCategoryTheater,
+      @"university" : MKPointOfInterestCategoryUniversity,
+      @"winery" : MKPointOfInterestCategoryWinery,
+      @"zoo" : MKPointOfInterestCategoryZoo,
+    };
+  });
+  return map[string];
+}
+
+- (void)applyPoiFilter {
+  if (!_poiEnabled) {
+    _mapView.pointOfInterestFilter = MKPointOfInterestFilter.filterExcludingAllCategories;
+    return;
+  }
+  if (_poiFilterCategories.count > 0) {
+    NSMutableArray<MKPointOfInterestCategory> *categories = [NSMutableArray array];
+    for (NSString *name in _poiFilterCategories) {
+      MKPointOfInterestCategory category = poiCategoryFromString(name);
+      if (category) {
+        [categories addObject:category];
+      }
+    }
+    if (categories.count > 0) {
+      if (_poiFilterMode == LuggMapViewPoiFilterMode::Excluding) {
+        _mapView.pointOfInterestFilter =
+            [[MKPointOfInterestFilter alloc] initExcludingCategories:categories];
+      } else {
+        _mapView.pointOfInterestFilter =
+            [[MKPointOfInterestFilter alloc] initIncludingCategories:categories];
+      }
+      return;
+    }
+  }
+  _mapView.pointOfInterestFilter = nil;
+}
+
+- (void)setPoiEnabled:(BOOL)enabled {
+  _poiEnabled = enabled;
+  [self applyPoiFilter];
+}
+
+- (void)setPoiFilterMode:(LuggMapViewPoiFilterMode)mode {
+  _poiFilterMode = mode;
+  [self applyPoiFilter];
+}
+
+- (void)setPoiFilterCategories:(NSArray<NSString *> *)categories {
+  _poiFilterCategories = categories;
+  [self applyPoiFilter];
 }
 
 - (void)setMapType:(LuggMapViewMapType)mapType {

--- a/ios/core/GoogleMapProvider.mm
+++ b/ios/core/GoogleMapProvider.mm
@@ -1,6 +1,7 @@
 #import "GoogleMapProvider.h"
 
 using facebook::react::LuggMapViewMapType;
+using facebook::react::LuggMapViewPoiFilterMode;
 using facebook::react::LuggMapViewTheme;
 
 #import "../LuggCalloutView.h"
@@ -166,6 +167,15 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
 
 - (void)setUserLocationEnabled:(BOOL)enabled {
   _mapView.myLocationEnabled = enabled;
+}
+
+- (void)setPoiEnabled:(BOOL)enabled {
+}
+
+- (void)setPoiFilterMode:(LuggMapViewPoiFilterMode)mode {
+}
+
+- (void)setPoiFilterCategories:(NSArray<NSString *> *)categories {
 }
 
 - (void)setMapType:(LuggMapViewMapType)mapType {

--- a/ios/core/MapProviderDelegate.h
+++ b/ios/core/MapProviderDelegate.h
@@ -56,6 +56,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setEdgeInsets:(UIEdgeInsets)edgeInsets
         oldEdgeInsets:(UIEdgeInsets)oldEdgeInsets
              duration:(double)duration;
+- (void)setPoiEnabled:(BOOL)enabled;
+- (void)setPoiFilterMode:(facebook::react::LuggMapViewPoiFilterMode)mode;
+- (void)setPoiFilterCategories:(NSArray<NSString *> *)categories;
 
 // Children
 - (void)addMarkerView:(LuggMarkerView *)markerView;

--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -25,6 +25,7 @@ export class MapView
     scrollEnabled: true,
     rotateEnabled: true,
     pitchEnabled: true,
+    poiEnabled: true,
     theme: 'system',
   };
 
@@ -94,6 +95,8 @@ export class MapView
       edgeInsets,
       userLocationEnabled,
       userLocationButtonEnabled,
+      poiEnabled,
+      poiFilter,
       theme,
       onPress,
       onLongPress,
@@ -122,6 +125,9 @@ export class MapView
         edgeInsets={edgeInsets}
         userLocationEnabled={userLocationEnabled}
         userLocationButtonEnabled={userLocationButtonEnabled}
+        poiEnabled={poiEnabled}
+        poiFilterMode={poiFilter?.mode}
+        poiFilterCategories={poiFilter?.categories}
         theme={theme}
         onMapPress={onPress}
         onMapLongPress={onLongPress}

--- a/src/MapView.types.ts
+++ b/src/MapView.types.ts
@@ -6,6 +6,7 @@ import type {
   Coordinate,
   EdgeInsets,
   MapTheme,
+  PoiFilter,
   PressEventPayload,
 } from './types';
 
@@ -127,6 +128,19 @@ export interface MapViewProps extends ViewProps {
    * @platform android
    */
   userLocationButtonEnabled?: boolean;
+  /**
+   * Show points of interest on the map (Apple Maps only).
+   * When false, hides all POIs regardless of poiFilter.
+   * @default true
+   * @platform ios
+   */
+  poiEnabled?: boolean;
+  /**
+   * Filter POI categories to show or hide (Apple Maps only).
+   * Only takes effect when poiEnabled is true.
+   * @platform ios
+   */
+  poiFilter?: PoiFilter;
   /**
    * Map color theme
    * @default 'system'

--- a/src/fabric/LuggMapViewNativeComponent.ts
+++ b/src/fabric/LuggMapViewNativeComponent.ts
@@ -78,6 +78,9 @@ export interface NativeProps extends ViewProps {
   edgeInsets?: EdgeInsets;
   userLocationEnabled?: boolean;
   userLocationButtonEnabled?: boolean;
+  poiEnabled?: boolean;
+  poiFilterMode?: WithDefault<'including' | 'excluding', 'including'>;
+  poiFilterCategories?: ReadonlyArray<string>;
   theme?: WithDefault<'light' | 'dark' | 'system', 'system'>;
   onMapPress?: DirectEventHandler<PressEvent>;
   onMapLongPress?: DirectEventHandler<LongPressEvent>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,8 @@ export type {
   Point,
   EdgeInsets,
   PressEventPayload,
+  PoiCategory,
+  PoiFilter,
 } from './types';
 export type {
   GeoJSON,

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -34,6 +34,8 @@ export type {
   Coordinate,
   Point,
   EdgeInsets,
+  PoiCategory,
+  PoiFilter,
 } from './types';
 export type {
   GeoJSON,

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,66 @@ export type MapType =
 export type MapTheme = 'light' | 'dark' | 'system';
 
 /**
+ * Point of interest category (Apple Maps)
+ */
+export type PoiCategory =
+  | 'airport'
+  | 'amusement-park'
+  | 'aquarium'
+  | 'atm'
+  | 'bakery'
+  | 'bank'
+  | 'beach'
+  | 'brewery'
+  | 'cafe'
+  | 'campground'
+  | 'car-rental'
+  | 'ev-charger'
+  | 'fire-station'
+  | 'fitness-center'
+  | 'food-market'
+  | 'gas-station'
+  | 'hospital'
+  | 'hotel'
+  | 'laundry'
+  | 'library'
+  | 'marina'
+  | 'movie-theater'
+  | 'museum'
+  | 'national-park'
+  | 'nightlife'
+  | 'park'
+  | 'parking'
+  | 'pharmacy'
+  | 'police'
+  | 'post-office'
+  | 'public-transport'
+  | 'restaurant'
+  | 'restroom'
+  | 'school'
+  | 'stadium'
+  | 'store'
+  | 'theater'
+  | 'university'
+  | 'winery'
+  | 'zoo';
+
+/**
+ * Point of interest filter
+ */
+export interface PoiFilter {
+  /**
+   * Filter mode
+   * @default 'including'
+   */
+  mode?: 'including' | 'excluding';
+  /**
+   * POI categories to include or exclude
+   */
+  categories: PoiCategory[];
+}
+
+/**
  * Press event payload
  */
 export interface PressEventPayload {


### PR DESCRIPTION
## Summary

Add `poiEnabled` and `poiFilter` props to MapView for controlling point of interest visibility on Apple Maps (iOS). Closes #46.

- `poiEnabled` — boolean (default `true`), hides all POIs when `false`
- `poiFilter` — `{ mode?: 'including' | 'excluding', categories: PoiCategory[] }` for granular category filtering via `MKPointOfInterestFilter`

No-op on Google Maps (iOS & Android) and web.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Set `poiEnabled={false}` on Apple Maps — POIs disappear
- Set `poiFilter={{ categories: ['cafe', 'restaurant'] }}` — only those POIs visible
- Set `poiFilter={{ mode: 'excluding', categories: ['parking'] }}` — all POIs except parking
- Verify `poiEnabled={false}` overrides `poiFilter`
- Verify Google Maps provider is unaffected (no-op)
- Verify Android builds and runs without errors

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)