### PR TITLE
feat: add centerOnPress prop to Marker

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggMarkerView.kt
+++ b/android/src/main/java/com/luggmaps/LuggMarkerView.kt
@@ -59,6 +59,9 @@ class LuggMarkerView(context: Context) : ReactViewGroup(context) {
   var rasterize: Boolean = true
     private set
 
+  var centerOnPress: Boolean = true
+    private set
+
   var draggable: Boolean = false
     private set
 
@@ -272,6 +275,10 @@ class LuggMarkerView(context: Context) : ReactViewGroup(context) {
 
   fun setRasterize(rasterize: Boolean) {
     this.rasterize = rasterize
+  }
+
+  fun setCenterOnPress(centerOnPress: Boolean) {
+    this.centerOnPress = centerOnPress
   }
 
   fun setDraggable(draggable: Boolean) {

--- a/android/src/main/java/com/luggmaps/LuggMarkerViewManager.kt
+++ b/android/src/main/java/com/luggmaps/LuggMarkerViewManager.kt
@@ -92,6 +92,11 @@ class LuggMarkerViewManager :
     view.setRasterize(value)
   }
 
+  @ReactProp(name = "centerOnPress", defaultBoolean = true)
+  override fun setCenterOnPress(view: LuggMarkerView, value: Boolean) {
+    view.setCenterOnPress(value)
+  }
+
   @ReactProp(name = "draggable", defaultBoolean = false)
   override fun setDraggable(view: LuggMarkerView, value: Boolean) {
     view.setDraggable(value)

--- a/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
+++ b/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
@@ -29,7 +29,6 @@ import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.Polygon
 import com.google.android.gms.maps.model.PolygonOptions
 import com.google.android.gms.maps.model.PolylineOptions
-import com.google.android.gms.maps.model.TileOverlay
 import com.google.android.gms.maps.model.TileOverlayOptions
 import com.google.android.gms.maps.model.UrlTileProvider
 import com.luggmaps.LuggCalloutView
@@ -48,6 +47,9 @@ import com.luggmaps.LuggTileOverlayView
 import com.luggmaps.LuggTileOverlayViewDelegate
 import com.luggmaps.extensions.findViewByTag
 import java.net.URL
+import kotlin.math.atan
+import kotlin.math.pow
+import kotlin.math.sinh
 
 class GoogleMapProvider(private val context: Context) :
   MapProvider,
@@ -305,8 +307,15 @@ class GoogleMapProvider(private val context: Context) :
 
       val calloutView = view.calloutView
       if (calloutView != null && !calloutView.bubbled && calloutView.hasCustomContent) {
-        googleMap?.animateCamera(CameraUpdateFactory.newLatLng(marker.position))
+        if (view.centerOnPress) {
+          googleMap?.animateCamera(CameraUpdateFactory.newLatLng(marker.position))
+        }
         showNonBubbledCallout(marker, calloutView)
+        return true
+      }
+
+      if (!view.centerOnPress) {
+        marker.showInfoWindow()
         return true
       }
     }
@@ -1058,9 +1067,9 @@ class GoogleMapProvider(private val context: Context) :
     val tileProvider = object : UrlTileProvider(tileSize, tileSize) {
       override fun getTileUrl(x: Int, y: Int, zoom: Int): URL? {
         if (hasBounds) {
-          val n = Math.pow(2.0, zoom.toDouble())
-          val tileSWLat = Math.toDegrees(Math.atan(Math.sinh(Math.PI * (1 - 2.0 * (y + 1) / n))))
-          val tileNELat = Math.toDegrees(Math.atan(Math.sinh(Math.PI * (1 - 2.0 * y / n))))
+          val n = 2.0.pow(zoom.toDouble())
+          val tileSWLat = Math.toDegrees(atan(sinh(Math.PI * (1 - 2.0 * (y + 1) / n))))
+          val tileNELat = Math.toDegrees(atan(sinh(Math.PI * (1 - 2.0 * y / n))))
           val tileSWLng = x / n * 360.0 - 180.0
           val tileNELng = (x + 1) / n * 360.0 - 180.0
 
@@ -1139,11 +1148,11 @@ class GoogleMapProvider(private val context: Context) :
     val map = googleMap ?: return
     if (coordinates.isEmpty()) return
 
-    val latLngs = coordinates.filterIsInstance<LatLng>()
-    if (latLngs.isEmpty()) return
+    val latLongs = coordinates.filterIsInstance<LatLng>()
+    if (latLongs.isEmpty()) return
 
-    val boundsBuilder = com.google.android.gms.maps.model.LatLngBounds.Builder()
-    latLngs.forEach { boundsBuilder.include(it) }
+    val boundsBuilder = LatLngBounds.Builder()
+    latLongs.forEach { boundsBuilder.include(it) }
     val bounds = boundsBuilder.build()
 
     val top = edgeInsetsTop.toFloat().dpToPx().toInt()
@@ -1265,7 +1274,9 @@ class GoogleMapProvider(private val context: Context) :
     }
   }
 
+  @Deprecated("Deprecated in Java")
   override fun onLowMemory() {}
+
   override fun onTrimMemory(level: Int) {}
 
   private fun applyTheme() {
@@ -1274,7 +1285,7 @@ class GoogleMapProvider(private val context: Context) :
       "light" -> MapColorScheme.LIGHT
       else -> MapColorScheme.FOLLOW_SYSTEM
     }
-    googleMap?.setMapColorScheme(colorScheme)
+    googleMap?.mapColorScheme = colorScheme
   }
 
   @SuppressLint("MissingPermission")

--- a/docs/MARKER.md
+++ b/docs/MARKER.md
@@ -39,6 +39,7 @@ import { MapView, Marker } from '@lugg/maps';
 | `rotate` | `number` | `0` | Rotation angle in degrees clockwise from north |
 | `scale` | `number` | `1` | Scale factor for the marker |
 | `rasterize` | `boolean` | `true` | Rasterize custom marker view to bitmap (iOS/Android only) |
+| `centerOnPress` | `boolean` | `true` | Whether the map centers on the marker when pressed |
 | `draggable` | `boolean` | `false` | Whether the marker can be dragged by the user |
 | `onPress` | `(event: MarkerPressEvent) => void` | - | Called when the marker is pressed. Event includes `coordinate` and `point` |
 | `onDragStart` | `(event: MarkerDragEvent) => void` | - | Called when marker drag starts. Event includes `coordinate` and `point` |

--- a/ios/LuggMarkerView.h
+++ b/ios/LuggMarkerView.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) CLLocationDegrees rotate;
 @property(nonatomic, readonly) CGFloat scale;
 @property(nonatomic, readonly) BOOL rasterize;
+@property(nonatomic, readonly) BOOL centerOnPress;
 @property(nonatomic, readonly) BOOL draggable;
 @property(nonatomic, readonly) BOOL hasCustomView;
 @property(nonatomic, readonly) BOOL didLayout;

--- a/ios/LuggMarkerView.mm
+++ b/ios/LuggMarkerView.mm
@@ -26,6 +26,7 @@ using namespace luggmaps::events;
   CLLocationDegrees _rotate;
   CGFloat _scale;
   BOOL _rasterize;
+  BOOL _centerOnPress;
   BOOL _draggable;
   BOOL _didLayout;
   UIView *_iconView;
@@ -49,6 +50,7 @@ using namespace luggmaps::events;
     _rotate = 0;
     _scale = 1;
     _rasterize = YES;
+    _centerOnPress = YES;
     _didLayout = NO;
 
     _iconView = [[UIView alloc] init];
@@ -78,6 +80,7 @@ using namespace luggmaps::events;
   _rotate = newViewProps.rotate;
   _scale = newViewProps.scale;
   _rasterize = newViewProps.rasterize;
+  _centerOnPress = newViewProps.centerOnPress;
   _draggable = newViewProps.draggable;
 }
 
@@ -172,6 +175,10 @@ using namespace luggmaps::events;
 
 - (BOOL)rasterize {
   return _rasterize;
+}
+
+- (BOOL)centerOnPress {
+  return _centerOnPress;
 }
 
 - (BOOL)draggable {

--- a/ios/core/AppleMapProvider.mm
+++ b/ios/core/AppleMapProvider.mm
@@ -1019,7 +1019,9 @@ static MKPointOfInterestCategory poiCategoryFromString(NSString *string) {
   if ([view.annotation isKindOfClass:[AppleMarkerAnnotation class]]) {
     AppleMarkerAnnotation *annotation =
         (AppleMarkerAnnotation *)view.annotation;
-    [_mapView setCenterCoordinate:annotation.coordinate animated:YES];
+    if (annotation.markerView.centerOnPress) {
+      [_mapView setCenterCoordinate:annotation.coordinate animated:YES];
+    }
   }
 }
 

--- a/ios/core/GoogleMapProvider.mm
+++ b/ios/core/GoogleMapProvider.mm
@@ -388,13 +388,21 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
 
     LuggCalloutView *calloutView = markerView.calloutView;
     if (calloutView && calloutView.hasCustomContent) {
-      [mapView animateToLocation:marker.position];
+      if (markerView.centerOnPress) {
+        [mapView animateToLocation:marker.position];
+      }
+
       mapView.selectedMarker = marker;
 
       if (!calloutView.bubbled) {
         [self showNonBubbledCallout:markerView];
       }
 
+      return YES;
+    }
+
+    if (!markerView.centerOnPress) {
+      mapView.selectedMarker = marker;
       return YES;
     }
   }

--- a/src/components/Marker.tsx
+++ b/src/components/Marker.tsx
@@ -58,6 +58,7 @@ export class Marker
       rotate = 0,
       scale = 1,
       rasterize = true,
+      centerOnPress = true,
       draggable = false,
       onPress,
       onDragStart,
@@ -88,6 +89,7 @@ export class Marker
         rotate={rotate}
         scale={scale}
         rasterize={rasterize}
+        centerOnPress={centerOnPress}
         draggable={draggable}
         onMarkerPress={onPress}
         onMarkerDragStart={onDragStart}

--- a/src/components/Marker.types.ts
+++ b/src/components/Marker.types.ts
@@ -74,6 +74,11 @@ export interface MarkerProps {
    */
   rasterize?: boolean;
   /**
+   * Whether the map centers on the marker when pressed.
+   * @default true
+   */
+  centerOnPress?: boolean;
+  /**
    * Whether the marker can be dragged by the user.
    * @default false
    */

--- a/src/components/Marker.web.tsx
+++ b/src/components/Marker.web.tsx
@@ -70,6 +70,7 @@ export const Marker = forwardRef<MarkerRef, MarkerProps>(
       zIndex,
       rotate,
       scale,
+      centerOnPress = true,
       draggable,
       onPress,
       onDragStart,
@@ -140,14 +141,22 @@ export const Marker = forwardRef<MarkerRef, MarkerProps>(
         const coord = pos
           ? { latitude: pos.lat, longitude: pos.lng }
           : coordinate;
-        moveCamera(coord);
+        if (centerOnPress) moveCamera(coord);
         onPress?.(createEvent(e, coordinate));
         if (hasCallout) {
           closeCallouts(closeCallout);
           setInfoWindowOpen((prev) => !prev);
         }
       },
-      [moveCamera, onPress, coordinate, hasCallout, closeCallouts, closeCallout]
+      [
+        centerOnPress,
+        moveCamera,
+        onPress,
+        coordinate,
+        hasCallout,
+        closeCallouts,
+        closeCallout,
+      ]
     );
 
     const handleDragStart = useCallback(

--- a/src/fabric/LuggMarkerViewNativeComponent.ts
+++ b/src/fabric/LuggMarkerViewNativeComponent.ts
@@ -25,6 +25,7 @@ export interface NativeProps extends ViewProps {
   rotate?: WithDefault<Double, 0>;
   scale?: WithDefault<Double, 1>;
   rasterize?: WithDefault<boolean, true>;
+  centerOnPress?: WithDefault<boolean, true>;
   draggable?: WithDefault<boolean, false>;
   onMarkerPress?: DirectEventHandler<{
     coordinate: {


### PR DESCRIPTION
## Summary

Add `centerOnPress` boolean prop to `Marker` (default `true`). When `false`, the map no longer auto-centers on the marker when pressed. Native callouts still display correctly.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Verified on iOS (Apple Maps + Google Maps), Android, and Web
- Tested `centerOnPress={true}` (default) — map centers on tap as before
- Tested `centerOnPress={false}` — map stays put, callout still shows

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [x] I tested on Web
- [x] I updated the documentation (if needed)