### PR TITLE
fix(android): dynamically update map overlay properties

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggMarkerView.kt
+++ b/android/src/main/java/com/luggmaps/LuggMarkerView.kt
@@ -10,6 +10,7 @@ import com.facebook.react.views.view.ReactViewGroup
 import com.google.android.gms.maps.model.AdvancedMarker
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.google.android.gms.maps.model.LatLng
 import com.luggmaps.events.MarkerDragEvent
 import com.luggmaps.events.MarkerPressEvent
 import com.luggmaps.extensions.dispatchEvent
@@ -246,6 +247,13 @@ class LuggMarkerView(context: Context) : ReactViewGroup(context) {
   fun setCoordinate(latitude: Double, longitude: Double) {
     this.latitude = latitude
     this.longitude = longitude
+    val m = marker ?: return
+    if (!isDragging) {
+      m.position = LatLng(latitude, longitude)
+      if (!rasterize) {
+        onUpdate?.invoke()
+      }
+    }
   }
 
   fun setTitle(title: String?) {

--- a/android/src/main/java/com/luggmaps/LuggPolygonView.kt
+++ b/android/src/main/java/com/luggmaps/LuggPolygonView.kt
@@ -43,10 +43,12 @@ class LuggPolygonView(context: Context) : ReactViewGroup(context) {
 
   fun setCoordinates(coords: List<LatLng>) {
     coordinates = coords
+    polygon?.points = coords
   }
 
   fun setHoles(value: List<List<LatLng>>) {
     holes = value
+    polygon?.holes = value
   }
 
   fun setStrokeColor(color: Int) {

--- a/android/src/main/java/com/luggmaps/LuggPolylineView.kt
+++ b/android/src/main/java/com/luggmaps/LuggPolylineView.kt
@@ -40,6 +40,7 @@ class LuggPolylineView(context: Context) : ReactViewGroup(context) {
 
   fun setCoordinates(coords: List<LatLng>) {
     coordinates = coords
+    polyline?.points = coords
   }
 
   fun setStrokeColors(colors: List<Int>) {


### PR DESCRIPTION
This patch enables coordinates, points, and holes to be updated dynamically for MarkerView, PolygonView, and PolylineView on Android without requiring a re-render. 

I've been using this patch in my project, and it is required when using react-native-reanimated map objects. It already works perfectly on iOS but this is needed on Android to achieve the same functionality.