### PR TITLE
refactor(android): use regular Marker instead of AdvancedMarker

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggMarkerView.kt
+++ b/android/src/main/java/com/luggmaps/LuggMarkerView.kt
@@ -7,9 +7,9 @@ import android.view.accessibility.AccessibilityEvent
 import androidx.core.graphics.createBitmap
 import androidx.core.view.isNotEmpty
 import com.facebook.react.views.view.ReactViewGroup
-import com.google.android.gms.maps.model.AdvancedMarker
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.google.android.gms.maps.model.Marker
 import com.luggmaps.events.MarkerDragEvent
 import com.luggmaps.events.MarkerPressEvent
 import com.luggmaps.extensions.dispatchEvent
@@ -38,7 +38,7 @@ class LuggMarkerView(context: Context) : ReactViewGroup(context) {
     private set
 
   var delegate: LuggMarkerViewDelegate? = null
-  var marker: AdvancedMarker? = null
+  var marker: Marker? = null
 
   var anchorX: Float = 0.5f
     private set

--- a/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
+++ b/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
@@ -15,8 +15,6 @@ import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.GoogleMapOptions
 import com.google.android.gms.maps.MapView
 import com.google.android.gms.maps.OnMapReadyCallback
-import com.google.android.gms.maps.model.AdvancedMarker
-import com.google.android.gms.maps.model.AdvancedMarkerOptions
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.CircleOptions
@@ -26,6 +24,7 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.maps.model.MapColorScheme
 import com.google.android.gms.maps.model.Marker
+import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.gms.maps.model.Polygon
 import com.google.android.gms.maps.model.PolygonOptions
 import com.google.android.gms.maps.model.PolylineOptions
@@ -692,12 +691,12 @@ class GoogleMapProvider(private val context: Context) :
     val map = googleMap ?: return
 
     val position = LatLng(markerView.latitude, markerView.longitude)
-    val options = AdvancedMarkerOptions()
+    val options = MarkerOptions()
       .position(position)
       .title(markerView.title)
       .snippet(markerView.description)
 
-    val marker = map.addMarker(options) as AdvancedMarker
+    val marker = map.addMarker(options) ?: return
     marker.setAnchor(markerView.anchorX, markerView.anchorY)
     marker.zIndex = markerView.zIndex
     marker.rotation = markerView.rotate
@@ -715,9 +714,8 @@ class GoogleMapProvider(private val context: Context) :
     }
   }
 
-  // Workaround: AdvancedMarker.iconView is buggy on Android, so we manually add the custom
-  // content view to the wrapper and position it via screen projection instead. The underlying
-  // marker uses a transparent bitmap matching the content size so taps still trigger onMarkerClick.
+  // Live marker: content view is added to the wrapper and positioned via screen projection.
+  // The underlying marker uses a transparent bitmap matching the content size so taps still trigger onMarkerClick.
   private fun showLiveMarker(markerView: LuggMarkerView) {
     val wrapper = wrapperView ?: return
 

--- a/example/bare/ios/Podfile.lock
+++ b/example/bare/ios/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - hermes-engine (0.14.0):
     - hermes-engine/Pre-built (= 0.14.0)
   - hermes-engine/Pre-built (0.14.0)
-  - LuggMaps (1.0.0-beta.6):
+  - LuggMaps (1.0.0-beta.11):
     - boost
     - DoubleConversion
     - fast_float
@@ -3202,7 +3202,7 @@ SPEC CHECKSUMS:
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   GoogleMaps: 0608099d4870cac8754bdba9b6953db543432438
   hermes-engine: 3515eff1a2de44b79dfa94a03d1adeed40f0dafe
-  LuggMaps: ae94261b276434379240235ff85192dcc541d66c
+  LuggMaps: 91958164a9ad4932293c33caf8386a35d478e914
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 2b70c6e3abe00396cefd8913efbf6a2db01a2b36
   RCTRequired: f3540eee8094231581d40c5c6d41b0f170237a81

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -78,7 +78,7 @@ clean_bare_example() {
   cd example/bare/android
   ./gradlew clean -q
   cd ../../..
-  npx pod-install example/bare
+  cd example/bare/ios && pod install && cd ../../..
 }
 
 clean_expo_example() {


### PR DESCRIPTION
## Summary

`iconView` is no longer used on Android, so the `AdvancedMarker` variant is unnecessary. Switched to the regular `Marker` / `MarkerOptions` API.

## Type of Change

- [x] Bug fix

## Test Plan

- Ran the bare example on Android emulator
- Verified markers render and respond to taps/drag
- Verified live (non-rasterized) markers still position correctly via screen projection

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)