### PR TITLE
fix(ios): respect custom duration for Apple map camera animations

### DIFF
--- a/example/shared/src/screens/HomeScreen.tsx
+++ b/example/shared/src/screens/HomeScreen.tsx
@@ -153,14 +153,14 @@ const HomeContent = ({ onMarkerPress: onMarkerPressProp }: HomeProps) => {
   const moveToRandomMarker = () => {
     if (markers.length === 0) return;
     const marker = randomFrom(markers);
-    mapRef.current?.moveCamera(marker.coordinate);
+    mapRef.current?.moveCamera(marker.coordinate, { duration: 2000 });
     mapRef.current?.showMarkerCallout(marker.id);
   };
 
   const fitAllMarkers = () => {
     mapRef.current?.fitCoordinates(
       markers.map((m) => m.coordinate),
-      { padding: { top: 60, left: 40, right: 40, bottom: 40 } }
+      { duration: 2000, padding: { top: 60, left: 40, right: 40, bottom: 40 } }
     );
   };
 

--- a/ios/core/AppleMapProvider.mm
+++ b/ios/core/AppleMapProvider.mm
@@ -1778,7 +1778,7 @@ static MKPointOfInterestCategory poiCategoryFromString(NSString *string) {
                                                           zoomLevel:targetZoom];
     [UIView animateWithDuration:duration / 1000.0
                      animations:^{
-                       [self->_mapView setRegion:region animated:NO];
+                       [self->_mapView setRegion:region animated:YES];
                      }];
   } else {
     [_mapView
@@ -1823,7 +1823,7 @@ static MKPointOfInterestCategory poiCategoryFromString(NSString *string) {
                      animations:^{
                        [self->_mapView setVisibleMapRect:mapRect
                                              edgePadding:insets
-                                                animated:NO];
+                                                animated:YES];
                      }];
   } else {
     [_mapView setVisibleMapRect:mapRect edgePadding:insets animated:NO];


### PR DESCRIPTION
Use animated MapKit updates in duration > 0 camera commands so moveCamera and fitCoordinates follow the provided duration instead of default timing.

## Summary

<!-- Describe what this PR does and why -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

<!-- How did you test these changes? -->

## Screenshots / Videos

<!-- Add screenshots or videos if applicable -->

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
