### PR TITLE
fix(ios): make event emit() templates compatible with RN 0.85+

### DIFF
--- a/ios/events/CameraIdleEvent.h
+++ b/ios/events/CameraIdleEvent.h
@@ -11,8 +11,10 @@ struct CameraIdleEvent {
   double zoom;
   bool gesture;
 
-  template <typename Emitter>
-  void emit(const facebook::react::SharedEventEmitter &eventEmitter) const {
+  // Holder type is templated to bridge RN versions: SharedEventEmitter went
+  // from shared_ptr<const EventEmitter> to shared_ptr<EventEmitter> in 0.85.
+  template <typename Emitter, typename EventEmitterPtr>
+  void emit(const EventEmitterPtr &eventEmitter) const {
     if (!eventEmitter)
       return;
     auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);

--- a/ios/events/CameraMoveEvent.h
+++ b/ios/events/CameraMoveEvent.h
@@ -11,8 +11,10 @@ struct CameraMoveEvent {
   double zoom;
   bool gesture;
 
-  template <typename Emitter>
-  void emit(const facebook::react::SharedEventEmitter &eventEmitter) const {
+  // Holder type is templated to bridge RN versions: SharedEventEmitter went
+  // from shared_ptr<const EventEmitter> to shared_ptr<EventEmitter> in 0.85.
+  template <typename Emitter, typename EventEmitterPtr>
+  void emit(const EventEmitterPtr &eventEmitter) const {
     if (!eventEmitter)
       return;
     auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);

--- a/ios/events/CirclePressEvent.h
+++ b/ios/events/CirclePressEvent.h
@@ -6,8 +6,10 @@ namespace luggmaps {
 namespace events {
 
 struct CirclePressEvent {
-  template <typename Emitter>
-  static void emit(const facebook::react::SharedEventEmitter &eventEmitter) {
+  // Holder type is templated to bridge RN versions: SharedEventEmitter went
+  // from shared_ptr<const EventEmitter> to shared_ptr<EventEmitter> in 0.85.
+  template <typename Emitter, typename EventEmitterPtr>
+  static void emit(const EventEmitterPtr &eventEmitter) {
     if (!eventEmitter)
       return;
     auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);

--- a/ios/events/GroundOverlayPressEvent.h
+++ b/ios/events/GroundOverlayPressEvent.h
@@ -6,8 +6,10 @@ namespace luggmaps {
 namespace events {
 
 struct GroundOverlayPressEvent {
-  template <typename Emitter>
-  static void emit(const facebook::react::SharedEventEmitter &eventEmitter) {
+  // Holder type is templated to bridge RN versions: SharedEventEmitter went
+  // from shared_ptr<const EventEmitter> to shared_ptr<EventEmitter> in 0.85.
+  template <typename Emitter, typename EventEmitterPtr>
+  static void emit(const EventEmitterPtr &eventEmitter) {
     if (!eventEmitter)
       return;
     auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);

--- a/ios/events/LongPressEvent.h
+++ b/ios/events/LongPressEvent.h
@@ -11,8 +11,10 @@ struct LongPressEvent {
   double x;
   double y;
 
-  template <typename Emitter>
-  void emit(const facebook::react::SharedEventEmitter &eventEmitter) const {
+  // Holder type is templated to bridge RN versions: SharedEventEmitter went
+  // from shared_ptr<const EventEmitter> to shared_ptr<EventEmitter> in 0.85.
+  template <typename Emitter, typename EventEmitterPtr>
+  void emit(const EventEmitterPtr &eventEmitter) const {
     if (!eventEmitter)
       return;
     auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);

--- a/ios/events/MarkerDragEvent.h
+++ b/ios/events/MarkerDragEvent.h
@@ -11,8 +11,10 @@ struct MarkerDragStartEvent {
   double x;
   double y;
 
-  template <typename Emitter>
-  void emit(const facebook::react::SharedEventEmitter &eventEmitter) const {
+  // Holder type is templated to bridge RN versions: SharedEventEmitter went
+  // from shared_ptr<const EventEmitter> to shared_ptr<EventEmitter> in 0.85.
+  template <typename Emitter, typename EventEmitterPtr>
+  void emit(const EventEmitterPtr &eventEmitter) const {
     if (!eventEmitter)
       return;
     auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);
@@ -31,8 +33,10 @@ struct MarkerDragChangeEvent {
   double x;
   double y;
 
-  template <typename Emitter>
-  void emit(const facebook::react::SharedEventEmitter &eventEmitter) const {
+  // Holder type is templated to bridge RN versions: SharedEventEmitter went
+  // from shared_ptr<const EventEmitter> to shared_ptr<EventEmitter> in 0.85.
+  template <typename Emitter, typename EventEmitterPtr>
+  void emit(const EventEmitterPtr &eventEmitter) const {
     if (!eventEmitter)
       return;
     auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);
@@ -51,8 +55,10 @@ struct MarkerDragEndEvent {
   double x;
   double y;
 
-  template <typename Emitter>
-  void emit(const facebook::react::SharedEventEmitter &eventEmitter) const {
+  // Holder type is templated to bridge RN versions: SharedEventEmitter went
+  // from shared_ptr<const EventEmitter> to shared_ptr<EventEmitter> in 0.85.
+  template <typename Emitter, typename EventEmitterPtr>
+  void emit(const EventEmitterPtr &eventEmitter) const {
     if (!eventEmitter)
       return;
     auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);

--- a/ios/events/MarkerPressEvent.h
+++ b/ios/events/MarkerPressEvent.h
@@ -11,8 +11,10 @@ struct MarkerPressEvent {
   double x;
   double y;
 
-  template <typename Emitter>
-  void emit(const facebook::react::SharedEventEmitter &eventEmitter) const {
+  // Holder type is templated to bridge RN versions: SharedEventEmitter went
+  // from shared_ptr<const EventEmitter> to shared_ptr<EventEmitter> in 0.85.
+  template <typename Emitter, typename EventEmitterPtr>
+  void emit(const EventEmitterPtr &eventEmitter) const {
     if (!eventEmitter)
       return;
     auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);

--- a/ios/events/PolygonPressEvent.h
+++ b/ios/events/PolygonPressEvent.h
@@ -6,8 +6,10 @@ namespace luggmaps {
 namespace events {
 
 struct PolygonPressEvent {
-  template <typename Emitter>
-  static void emit(const facebook::react::SharedEventEmitter &eventEmitter) {
+  // Holder type is templated to bridge RN versions: SharedEventEmitter went
+  // from shared_ptr<const EventEmitter> to shared_ptr<EventEmitter> in 0.85.
+  template <typename Emitter, typename EventEmitterPtr>
+  static void emit(const EventEmitterPtr &eventEmitter) {
     if (!eventEmitter)
       return;
     auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);

--- a/ios/events/PressEvent.h
+++ b/ios/events/PressEvent.h
@@ -11,8 +11,10 @@ struct PressEvent {
   double x;
   double y;
 
-  template <typename Emitter>
-  void emit(const facebook::react::SharedEventEmitter &eventEmitter) const {
+  // Holder type is templated to bridge RN versions: SharedEventEmitter went
+  // from shared_ptr<const EventEmitter> to shared_ptr<EventEmitter> in 0.85.
+  template <typename Emitter, typename EventEmitterPtr>
+  void emit(const EventEmitterPtr &eventEmitter) const {
     if (!eventEmitter)
       return;
     auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);

--- a/ios/events/ReadyEvent.h
+++ b/ios/events/ReadyEvent.h
@@ -6,8 +6,10 @@ namespace luggmaps {
 namespace events {
 
 struct ReadyEvent {
-  template <typename Emitter>
-  static void emit(const facebook::react::SharedEventEmitter &eventEmitter) {
+  // Holder type is templated to bridge RN versions: SharedEventEmitter went
+  // from shared_ptr<const EventEmitter> to shared_ptr<EventEmitter> in 0.85.
+  template <typename Emitter, typename EventEmitterPtr>
+  static void emit(const EventEmitterPtr &eventEmitter) {
     if (!eventEmitter)
       return;
     auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);

--- a/ios/events/TileOverlayPressEvent.h
+++ b/ios/events/TileOverlayPressEvent.h
@@ -6,8 +6,10 @@ namespace luggmaps {
 namespace events {
 
 struct TileOverlayPressEvent {
-  template <typename Emitter>
-  static void emit(const facebook::react::SharedEventEmitter &eventEmitter) {
+  // Holder type is templated to bridge RN versions: SharedEventEmitter went
+  // from shared_ptr<const EventEmitter> to shared_ptr<EventEmitter> in 0.85.
+  template <typename Emitter, typename EventEmitterPtr>
+  static void emit(const EventEmitterPtr &eventEmitter) {
     if (!eventEmitter)
       return;
     auto emitter = std::static_pointer_cast<Emitter const>(eventEmitter);


### PR DESCRIPTION
## Summary

React Native 0.85 (shipped in Expo SDK 56) changed `facebook::react::SharedEventEmitter` from `shared_ptr<const EventEmitter>` to `shared_ptr<EventEmitter>` (const dropped). `RCTViewComponentView` still holds `_eventEmitter` as `SharedViewEventEmitter` (`shared_ptr<const ViewEventEmitter>`), so the implicit conversion from `shared_ptr<const ViewEventEmitter>` to the new non-const `SharedEventEmitter` no longer compiles — `shared_ptr` won't strip const implicitly.

This PR templatizes the holder parameter on each event's `emit()` so the type is deduced from the call site. The `static_pointer_cast<Emitter const>(...)` body works unchanged for both old and new RN versions. No call site changes are needed because the second template parameter is deduced.

We hit this downstream when integrating @lugg/maps with Expo SDK 56 / RN 0.85.3 and have been carrying it as a `patches/` override.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Compiled the package against RN 0.85.3 (Expo SDK 56) in our consumer app — previously failed with const-conversion error on `_eventEmitter`, now builds clean.
- `example/bare` still on RN 0.83.0 — backward-compatible: the templated holder deduces to the old `SharedEventEmitter` and behaves identically.

## Screenshots / Videos

N/A — C++ header-only change.

## Checklist

- [x] I tested on iOS
- [x] I tested on Android (no changes — Android dispatches events from Kotlin)
- [ ] I tested on Web (N/A)
- [ ] I updated the documentation (not needed — internal C++ signature, not a public API)