### PR TITLE
fix(camera): preserve heading/pitch in moveCamera

### DIFF
--- a/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
+++ b/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
@@ -16,6 +16,7 @@ import com.google.android.gms.maps.GoogleMapOptions
 import com.google.android.gms.maps.MapView
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.CircleOptions
 import com.google.android.gms.maps.model.GroundOverlay
@@ -1143,7 +1144,11 @@ class GoogleMapProvider(private val context: Context) :
     val map = googleMap ?: return
     val position = LatLng(latitude, longitude)
     val targetZoom = if (zoom > 0) zoom.toFloat() else map.cameraPosition.zoom
-    val cameraUpdate = CameraUpdateFactory.newLatLngZoom(position, targetZoom)
+    val cameraPosition = CameraPosition.Builder(map.cameraPosition)
+      .target(position)
+      .zoom(targetZoom)
+      .build()
+    val cameraUpdate = CameraUpdateFactory.newCameraPosition(cameraPosition)
     when {
       duration < 0 -> map.animateCamera(cameraUpdate)
       duration > 0 -> map.animateCamera(cameraUpdate, duration, null)

--- a/docs/MAPVIEW.md
+++ b/docs/MAPVIEW.md
@@ -201,7 +201,7 @@ mapRef.current?.setEdgeInsets(
 
 ### moveCamera
 
-Move the camera to a coordinate with optional zoom and animation duration.
+Move the camera to a coordinate with optional zoom and animation duration. The current heading and pitch are preserved.
 
 ```ts
 moveCamera(coordinate: Coordinate, options: MoveCameraOptions): void
@@ -214,7 +214,7 @@ interface MoveCameraOptions {
 
 ### fitCoordinates
 
-Fit multiple coordinates in the visible map area.
+Fit multiple coordinates in the visible map area. Resets heading to north (`0°`).
 
 ```ts
 fitCoordinates(coordinates: Coordinate[], options?: FitCoordinatesOptions): void

--- a/ios/core/AppleMapProvider.mm
+++ b/ios/core/AppleMapProvider.mm
@@ -1778,11 +1778,11 @@ static MKPointOfInterestCategory poiCategoryFromString(NSString *string) {
   } else if (duration > 0) {
     CLLocationCoordinate2D center =
         CLLocationCoordinate2DMake(latitude, longitude);
-    MKCoordinateRegion region = [_mapView regionForCenterCoordinate:center
-                                                          zoomLevel:targetZoom];
+    MKMapCamera *camera = [_mapView cameraForCenterCoordinate:center
+                                                    zoomLevel:targetZoom];
     [UIView animateWithDuration:duration / 1000.0
                      animations:^{
-                       [self->_mapView setRegion:region animated:NO];
+                       [self->_mapView setCamera:camera animated:NO];
                      }];
   } else {
     [_mapView

--- a/ios/core/GoogleMapProvider.mm
+++ b/ios/core/GoogleMapProvider.mm
@@ -1129,9 +1129,11 @@ static NSString *const kDemoMapId = @"DEMO_MAP_ID";
     return;
 
   float targetZoom = zoom > 0 ? (float)zoom : _mapView.camera.zoom;
-  GMSCameraPosition *camera = [GMSCameraPosition cameraWithLatitude:latitude
-                                                          longitude:longitude
-                                                               zoom:targetZoom];
+  GMSCameraPosition *camera = [GMSCameraPosition
+      cameraWithTarget:CLLocationCoordinate2DMake(latitude, longitude)
+                  zoom:targetZoom
+               bearing:_mapView.camera.bearing
+          viewingAngle:_mapView.camera.viewingAngle];
   if (duration < 0) {
     [_mapView animateToCameraPosition:camera];
   } else if (duration > 0) {

--- a/ios/extensions/MKMapView+Zoom.h
+++ b/ios/extensions/MKMapView+Zoom.h
@@ -8,6 +8,11 @@ NS_ASSUME_NONNULL_BEGIN
                   zoomLevel:(double)zoomLevel
                    animated:(BOOL)animated;
 
+/// Returns a camera for the given center and zoom level, preserving the current
+/// heading and pitch
+- (MKMapCamera *)cameraForCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
+                                 zoomLevel:(double)zoomLevel;
+
 - (MKCoordinateRegion)regionForCenterCoordinate:
                           (CLLocationCoordinate2D)centerCoordinate
                                       zoomLevel:(double)zoomLevel;

--- a/ios/extensions/MKMapView+Zoom.m
+++ b/ios/extensions/MKMapView+Zoom.m
@@ -22,9 +22,8 @@
 // Constant for altitude/zoom conversion (meters at zoom level 0)
 static const double kAltitudeAtZoomZero = 220000000.0;
 
-- (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
-                  zoomLevel:(double)zoomLevel
-                   animated:(BOOL)animated
+- (MKMapCamera *)cameraForCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
+                                 zoomLevel:(double)zoomLevel
 {
     // Use camera API directly to avoid region/margin interaction
     CLLocationDistance altitude = kAltitudeAtZoomZero / pow(2, zoomLevel);
@@ -33,6 +32,15 @@ static const double kAltitudeAtZoomZero = 220000000.0;
                                                           eyeAltitude:altitude];
     camera.pitch = self.camera.pitch;
     camera.heading = self.camera.heading;
+    return camera;
+}
+
+- (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
+                  zoomLevel:(double)zoomLevel
+                   animated:(BOOL)animated
+{
+    MKMapCamera *camera = [self cameraForCenterCoordinate:centerCoordinate
+                                                zoomLevel:zoomLevel];
     [self setCamera:camera animated:animated];
 }
 


### PR DESCRIPTION
## Summary

`moveCamera(...)` rebuilt the camera from target + zoom only, dropping the current heading/bearing and tilt/pitch to `0`. This fixes [#75](https://github.com/lugg/maps/issues/75) by building from the current camera across all three providers:

- **Android (Google)** — `CameraPosition.Builder(map.cameraPosition)` copy-constructor carries bearing + tilt, replacing `newLatLngZoom`.
- **iOS (Google)** — `cameraWithTarget:zoom:bearing:viewingAngle:`, feeding `bearing`/`viewingAngle` from the current camera.
- **iOS (Apple)** — the `duration > 0` branch routed through north-up `setRegion:`; it now drives `MKMapCamera`. Extracted `cameraForCenterCoordinate:zoomLevel:` in `MKMapView+Zoom` so the animated path and the existing setter share one altitude/heading source.

`fitCoordinates(...)` is intentionally **not** changed: the native bounds-fit APIs (`newLatLngBounds`, `fitBounds:withEdgeInsets:`, `setVisibleMapRect:`) are north-up only, with no native way to fit rotated bounds. Docs updated to note this.

## Type of Change

- [x] Bug fix

## Test Plan

Rotate the map to a non-zero heading, then trigger `moveCamera(...)` (all duration modes) and confirm the heading/pitch is preserved on iOS (Apple + Google) and Android.

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)