### PR TITLE
chore(deps): move @expo/config-plugins to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@eslint/compat": "^1.3.2",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.35.0",
+    "@expo/config-plugins": "^56.0.8",
     "@react-native/babel-preset": "0.85.3",
     "@react-native/eslint-config": "0.85.3",
     "@react-native/jest-preset": "0.85.3",
@@ -102,16 +103,17 @@
   },
   "peerDependencies": {
     "@vis.gl/react-google-maps": ">=1.0.0",
+    "expo": "*",
     "react": "*",
     "react-native": "*"
   },
   "peerDependenciesMeta": {
     "@vis.gl/react-google-maps": {
       "optional": true
+    },
+    "expo": {
+      "optional": true
     }
-  },
-  "dependencies": {
-    "@expo/config-plugins": "^56.0.8"
   },
   "workspaces": [
     "example/bare",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3402,10 +3402,13 @@ __metadata:
     typescript: "npm:^5.9.2"
   peerDependencies:
     "@vis.gl/react-google-maps": ">=1.0.0"
+    expo: "*"
     react: "*"
     react-native: "*"
   peerDependenciesMeta:
     "@vis.gl/react-google-maps":
+      optional: true
+    expo:
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

`@expo/config-plugins` was listed as a runtime `dependency`, but it's only used by the Expo config plugin (`plugin/src`) that runs at prebuild time. Expo apps already bundle `@expo/config-plugins` via `expo`, so shipping it as a runtime dep risks duplicate/mismatched versions in consumers.

- Move `@expo/config-plugins` to `devDependencies` (for typechecking the plugin source).
- Add `expo` as an optional peer dependency.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- [x] `yarn typecheck` passes
- [x] `yarn build:plugin` succeeds
- [x] Plugin still resolves `@expo/config-plugins` from the consumer (Expo app) at prebuild time

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)