### PR TITLE
fix(ios): prevent crash on Google Maps animated gradient polyline

### DIFF
--- a/example/bare/ios/Podfile.lock
+++ b/example/bare/ios/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - hermes-engine (250829098.0.10):
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
-  - LuggMaps (1.0.0-beta.14):
+  - LuggMaps (1.0.0-beta.16):
     - GoogleMaps
     - hermes-engine
     - RCTRequired
@@ -2427,7 +2427,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
   GoogleMaps: 0608099d4870cac8754bdba9b6953db543432438
   hermes-engine: a43fcac5345a0a468667778019547c5fd282c6e2
-  LuggMaps: b69f00e83f91bd2e00fb32341dff2d2cc57e794a
+  LuggMaps: 7f6539e8b1f2d1c328f6c9634cc0544a78b39076
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
   RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc
   RCTSwiftUI: 239ed2eb9e73de5a6f518810630f0c95e01c8702

--- a/example/shared/src/components/CrewMarker.tsx
+++ b/example/shared/src/components/CrewMarker.tsx
@@ -21,6 +21,7 @@ interface CrewMarkerProps {
   loaded?: boolean;
   speed?: number;
   zoom?: number;
+  onSegment?: (index: number) => void;
 }
 
 const getBearing = (from: Coordinate, to: Coordinate, currentBearing = 0) => {
@@ -57,7 +58,10 @@ export const CrewMarker = ({
   loaded = false,
   speed = 1,
   zoom = BASE_ZOOM,
+  onSegment,
 }: CrewMarkerProps) => {
+  const onSegmentRef = useRef(onSegment);
+  onSegmentRef.current = onSegment;
   const latitude = useSharedValue(route[0]?.latitude ?? 0);
   const longitude = useSharedValue(route[0]?.longitude ?? 0);
   const bearingValue = useSharedValue(0);
@@ -101,6 +105,8 @@ export const CrewMarker = ({
         animateSegment(0);
         return;
       }
+
+      onSegmentRef.current?.(index);
 
       const from = route[index]!;
       const to = route[index + 1]!;

--- a/example/shared/src/components/Map.tsx
+++ b/example/shared/src/components/Map.tsx
@@ -310,6 +310,12 @@ export const Map = memo(
         [markers]
       );
 
+      const [truckIndex, setTruckIndex] = useState(0);
+      const routeAhead = useMemo(
+        () => smoothedRoute.slice(truckIndex),
+        [smoothedRoute, truckIndex]
+      );
+
       const centerPinStyle = useAnimatedStyle(() => {
         const bottom = animatedPosition
           ? screenHeight - animatedPosition.value
@@ -353,8 +359,12 @@ export const Map = memo(
                 provider === 'apple' || Platform.OS === 'android'
               )
             )}
-            <Route coordinates={smoothedRoute} />
-            <CrewMarker route={smoothedRoute} zoom={zoom} />
+            <Route coordinates={routeAhead} />
+            <CrewMarker
+              route={smoothedRoute}
+              zoom={zoom}
+              onSegment={setTruckIndex}
+            />
             <Polygon
               coordinates={CIRCLE_COORDS}
               holes={CIRCLE_HOLES}

--- a/ios/core/GMSPolylineAnimator.m
+++ b/ios/core/GMSPolylineAnimator.m
@@ -148,13 +148,25 @@ static const NSUInteger kMaxGradientSpans = 512;
   }
 
   GMSMutablePath *path = [GMSMutablePath path];
-  for (CLLocation *location in self.coordinates) {
-    [path addCoordinate:location.coordinate];
+  CLLocationCoordinate2D lastCoord = self.coordinates.firstObject.coordinate;
+  [path addCoordinate:lastCoord];
+  for (NSUInteger i = 1; i < self.coordinates.count; i++) {
+    CLLocationCoordinate2D coord = self.coordinates[i].coordinate;
+    if (coord.latitude == lastCoord.latitude && coord.longitude == lastCoord.longitude) {
+      continue;
+    }
+    [path addCoordinate:coord];
+    lastCoord = coord;
   }
+
+  // Clear stale spans before swapping the path so Google Maps never rebuilds
+  // span models against a path with fewer segments (GMSModelStyleBuilder
+  // couldNotInstantiate -> EXC_BAD_ACCESS). Reassign spans once the new path is set.
+  _polyline.spans = nil;
   _polyline.path = path;
 
-  if (self.strokeColors.count > 1) {
-    _polyline.spans = [self createGradientSpans];
+  if (path.count > 1 && self.strokeColors.count > 1) {
+    _polyline.spans = [self createGradientSpansForSegmentCount:path.count - 1];
   } else {
     _polyline.strokeColor = self.strokeColors.firstObject ?: [UIColor blackColor];
   }
@@ -222,35 +234,44 @@ static const NSUInteger kMaxGradientSpans = 512;
   }
 
   if (headDist <= tailDist) {
+    _polyline.spans = nil;
     _polyline.path = [GMSMutablePath path];
     return;
   }
 
-  CGFloat visibleLength = headDist - tailDist;
   NSUInteger startIndex = [self indexForDistance:tailDist];
   NSUInteger endIndex = [self indexForDistance:headDist];
 
   GMSMutablePath *path = [GMSMutablePath path];
-  NSMutableArray<GMSStyleSpan *> *spans = [NSMutableArray array];
 
-  CLLocationCoordinate2D startCoord = [self coordinateAtDistance:tailDist];
-  [path addCoordinate:startCoord];
+  CLLocationCoordinate2D lastCoord = [self coordinateAtDistance:tailDist];
+  [path addCoordinate:lastCoord];
 
   for (NSUInteger i = startIndex + 1; i <= endIndex; i++) {
-    [path addCoordinate:self.coordinates[i].coordinate];
+    CLLocationCoordinate2D coord = self.coordinates[i].coordinate;
+    if (coord.latitude == lastCoord.latitude && coord.longitude == lastCoord.longitude) {
+      continue;
+    }
+    [path addCoordinate:coord];
+    lastCoord = coord;
   }
 
   CLLocationCoordinate2D endCoord = [self coordinateAtDistance:headDist];
-  CLLocationCoordinate2D lastAdded =
-      (endIndex < self.coordinates.count) ? self.coordinates[endIndex].coordinate : endCoord;
-  if (endCoord.latitude != lastAdded.latitude || endCoord.longitude != lastAdded.longitude) {
+  if (endCoord.latitude != lastCoord.latitude || endCoord.longitude != lastCoord.longitude) {
     [path addCoordinate:endCoord];
   }
 
   NSUInteger pathCount = path.count;
-  NSUInteger segmentCount = pathCount - 1;
+  NSUInteger segmentCount = (pathCount > 1) ? pathCount - 1 : 0;
+
+  if (segmentCount == 0) {
+    _polyline.spans = nil;
+    _polyline.path = path;
+    return;
+  }
 
   if (self.strokeColors.count <= 1) {
+    _polyline.spans = nil;
     _polyline.path = path;
     _polyline.strokeColor = self.strokeColors.firstObject ?: [UIColor blackColor];
     return;
@@ -259,6 +280,7 @@ static const NSUInteger kMaxGradientSpans = 512;
   NSUInteger spanCount = MIN(segmentCount, kMaxAnimationSpans);
   double segmentsPerSpan = (double)segmentCount / spanCount;
 
+  NSMutableArray<GMSStyleSpan *> *spans = [NSMutableArray array];
   for (NSUInteger i = 0; i < spanCount; i++) {
     CGFloat gradientPos = ((CGFloat)i + 0.5) / spanCount;
     UIColor *color = [self colorAtGradientPosition:gradientPos];
@@ -266,13 +288,16 @@ static const NSUInteger kMaxGradientSpans = 512;
     [spans addObject:[GMSStyleSpan spanWithStyle:style segments:segmentsPerSpan]];
   }
 
+  // Clear stale spans before swapping the path so Google Maps never rebuilds
+  // span models against a path with fewer segments (GMSModelStyleBuilder
+  // couldNotInstantiate -> EXC_BAD_ACCESS). Reassign spans once the new path is set.
+  _polyline.spans = nil;
   _polyline.path = path;
   _polyline.spans = spans;
 }
 
-- (NSArray<GMSStyleSpan *> *)createGradientSpans {
+- (NSArray<GMSStyleSpan *> *)createGradientSpansForSegmentCount:(NSUInteger)segmentCount {
   NSMutableArray<GMSStyleSpan *> *spans = [NSMutableArray array];
-  NSUInteger segmentCount = self.coordinates.count - 1;
   NSUInteger spanCount = MIN(segmentCount, kMaxGradientSpans);
   double segmentsPerSpan = (double)segmentCount / spanCount;
 


### PR DESCRIPTION
Fixes ENG-1150.

## Summary

Fixes a native iOS crash (`EXC_BAD_ACCESS` / `GMSModelStyleBuilder couldNotInstantiate`) on animated Google Maps gradient polylines, surfaced by TestFlight crash reports in the Lugg Mover app (ENG-1150).

Each display-link tick assigned `_polyline.path = path` then `_polyline.spans = spans`. Setting the new (shorter) path while the *previous* tick's spans were still attached makes Google Maps rebuild span models for segments that no longer exist → throws in `GMSModelStyleBuilder`. The empty-path branch (`headDist <= tailDist`) was the worst case: it shrank the path to empty but left stale spans.

The fix preserves the gradient rather than falling back to a solid stroke:

- Clear `_polyline.spans = nil` **before** swapping to a shorter/empty path, then reassign spans once the new path is set, so path and spans are never inconsistent.
- Guard the zero-segment case (clear spans, set path, return).
- Drop duplicate adjacent coordinates while building the path (zero-length segments also fail model-style instantiation).
- Apply the same hardening to the non-animated `update` path; `createGradientSpans` now keys off the deduped path's actual segment count.

Also adds an example smoke test: the gradient route is sliced to the path ahead of the moving truck, so `coordinates` mutate mid-animation — mirroring the live-route scenario from the crash.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Ran the example on iOS (Google provider) with the truck-driven gradient polyline; gradient renders and animates with no crash.
- Note: the original crash reproduces under live GPS on device; the fix removes the path/spans inconsistency window identified in the symbolicated backtrace.

## Screenshots / Videos

N/A

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)