### PR TITLE
fix(android): reduce polyline update churn causing OOM

### DIFF
--- a/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
+++ b/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
@@ -867,13 +867,11 @@ class GoogleMapProvider(private val context: Context) :
       return
     }
 
-    polylineView.polyline?.width = polylineView.strokeWidth.dpToPx()
-    polylineView.polyline?.zIndex = polylineView.zIndex
-
     polylineAnimators[polylineView]?.apply {
       coordinates = polylineView.coordinates
       strokeColors = polylineView.strokeColors
       strokeWidth = polylineView.strokeWidth.dpToPx()
+      zIndex = polylineView.zIndex
       animatedOptions = polylineView.animatedOptions
       animated = polylineView.animated && !staticMode
       update()
@@ -903,6 +901,7 @@ class GoogleMapProvider(private val context: Context) :
       coordinates = polylineView.coordinates
       strokeColors = polylineView.strokeColors
       strokeWidth = polylineView.strokeWidth.dpToPx()
+      zIndex = polylineView.zIndex
       animatedOptions = polylineView.animatedOptions
       // Static maps render once; show the full polyline instead of animating
       animated = polylineView.animated && !staticMode

--- a/android/src/main/java/com/luggmaps/core/PolylineAnimator.kt
+++ b/android/src/main/java/com/luggmaps/core/PolylineAnimator.kt
@@ -16,12 +16,19 @@ class PolylineAnimator {
   companion object {
     private const val MAX_ANIMATION_SPANS = 16
     private const val MAX_GRADIENT_SPANS = 512
+
+    // Cap polyline updates to ~60fps; every update crosses Binder into the
+    // maps renderer, and 120Hz displays double that churn (CONSUMER-APP-44Y)
+    private const val MIN_UPDATE_INTERVAL_NANOS = 16_000_000L
   }
 
   var polyline: Polyline? = null
   var coordinates: List<LatLng> = emptyList()
     set(value) {
-      if (field === value) return
+      // Structural equality: Fabric delivers a new list instance on every
+      // commit, so identity checks never match and the full route would be
+      // re-parceled across Binder even when unchanged
+      if (field == value) return
       field = value
       dirty = true
       if (animated && animator != null) {
@@ -30,11 +37,22 @@ class PolylineAnimator {
     }
   var strokeColors: List<Int> = listOf(Color.BLACK)
     set(value) {
-      if (field === value) return
+      if (field == value) return
       field = value
       dirty = true
     }
   var strokeWidth: Float = 1f
+    set(value) {
+      if (field == value) return
+      field = value
+      polyline?.width = value
+    }
+  var zIndex: Float = 0f
+    set(value) {
+      if (field == value) return
+      field = value
+      polyline?.zIndex = value
+    }
   var animatedOptions: AnimatedOptions = AnimatedOptions()
     set(value) {
       if (field == value) return
@@ -58,6 +76,8 @@ class PolylineAnimator {
 
   private var animator: ValueAnimator? = null
   private var animationProgress: Float = 0f
+  private var lastUpdateNanos: Long = 0L
+  private var lastAppliedColor: Int? = null
   private var cumulativeDistances: FloatArray = floatArrayOf()
   private var totalLength: Float = 0f
   private var dirty: Boolean = true
@@ -91,8 +111,11 @@ class PolylineAnimator {
 
     if (strokeColors.size > 1) {
       applyGradientSpans(poly)
+      lastAppliedColor = null
     } else {
-      poly.color = strokeColors.firstOrNull() ?: Color.BLACK
+      val color = strokeColors.firstOrNull() ?: Color.BLACK
+      poly.color = color
+      lastAppliedColor = color
     }
   }
 
@@ -111,6 +134,9 @@ class PolylineAnimator {
       interpolator = LinearInterpolator()
       addUpdateListener { animation ->
         animationProgress = animation.animatedValue as Float
+        val now = System.nanoTime()
+        if (now - lastUpdateNanos < MIN_UPDATE_INTERVAL_NANOS) return@addUpdateListener
+        lastUpdateNanos = now
         updateAnimatedPolyline()
       }
       start()
@@ -182,6 +208,7 @@ class PolylineAnimator {
   private fun stopAnimation() {
     animator?.cancel()
     animator = null
+    lastUpdateNanos = 0L
   }
 
   fun pause() {
@@ -222,6 +249,7 @@ class PolylineAnimator {
     if (headDist <= tailDist) {
       val point = coordinates.firstOrNull() ?: LatLng(0.0, 0.0)
       poly.color = strokeColors.firstOrNull() ?: Color.BLACK
+      lastAppliedColor = null
       poly.points = listOf(point, point)
       return
     }
@@ -246,12 +274,13 @@ class PolylineAnimator {
 
     if (reusablePoints.size < 2) return
 
-    // Clear spans before setting points to prevent IndexOutOfBoundsException
-    // when the new points list is shorter than what existing spans reference
-    poly.color = strokeColors.firstOrNull() ?: Color.BLACK
-    poly.points = reusablePoints
-
     if (strokeColors.size > 1) {
+      // Clear spans before setting points to prevent IndexOutOfBoundsException
+      // when the new points list is shorter than what existing spans reference
+      poly.color = strokeColors.firstOrNull() ?: Color.BLACK
+      lastAppliedColor = null
+      poly.points = reusablePoints
+
       val segmentCount = reusablePoints.size - 1
       val spanCount = min(segmentCount, MAX_ANIMATION_SPANS)
       val segmentsPerSpan = segmentCount.toDouble() / spanCount
@@ -263,6 +292,13 @@ class PolylineAnimator {
         reusableSpans.add(StyleSpan(StrokeStyle.colorBuilder(color).build(), segmentsPerSpan))
       }
       poly.setSpans(reusableSpans)
+    } else {
+      val color = strokeColors.firstOrNull() ?: Color.BLACK
+      if (lastAppliedColor != color) {
+        poly.color = color
+        lastAppliedColor = color
+      }
+      poly.points = reusablePoints
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes [CONSUMER-APP-44Y](https://lugg.sentry.io/issues/CONSUMER-APP-44Y) — fatal `OutOfMemoryError` at `syncPolylineView`/`PolylineAnimator.update` (19 events, 15 users). Trivial allocations fail with the 256MB heap exhausted; the polyline sync path is the hottest allocator, hammered by redundant Binder transactions into the GMS renderer:

- `setWidth`/`setZIndex` fired on **every** React commit even when unchanged (`Polyline.setWidth` is the literal crash frame)
- `poly.color` set on **every** animation frame
- Animation updates ran at display refresh — 120Hz devices doubled the churn
- Dirty-check used identity (`===`), but Fabric delivers new list instances per commit — content-equal coordinates re-parceled the full route and re-applied up to 512 gradient spans

Changes:
- Cap animation updates to ~60fps (`MIN_UPDATE_INTERVAL_NANOS`)
- Move `strokeWidth`/`zIndex` into `PolylineAnimator` with change-guards
- Guard per-frame `poly.color` in the single-color path (gradient path keeps the unconditional set — it clears stale spans, see #67)
- Structural equality on `coordinates`/`strokeColors` dirty-checks

Per-frame cost drops from 3–4 Binder transactions @120Hz to 1 (`setPoints`) @≤60Hz for the common solid-color animated route. Companion consumer-app fix gates the live-tracking trailing-position updates that drove commits 5×/s.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Traced crash line numbers (Sentry release `3.2.18+763`) to beta.15–17 sources to confirm all prior OOM fixes (#66, #67, #69, #72) were already present in crashing builds
- Verified gradient span-clearing behavior from #67 is preserved (unconditional color set before shrinking points)

## Screenshots / Videos

N/A

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lugg/codesmith/maps/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786635833&installation_id=139852181&pr_number=88&repository=lugg%2Fmaps&return_to=https%3A%2F%2Fgithub.com%2Flugg%2Fmaps%2Fpull%2F88&signature=a57a83f4c13f22eb1538bd5e1b522f9c04ef44f6a1f3c8242fea370ca0b91b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->