### PR TITLE
feat: add MapView reload

### DIFF
--- a/android/src/main/java/com/luggmaps/LuggMapView.kt
+++ b/android/src/main/java/com/luggmaps/LuggMapView.kt
@@ -131,7 +131,7 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
 
   // region Provider Initialization
 
-  private fun initializeProvider() {
+  private fun initializeProvider(latitude: Double = initialLatitude, longitude: Double = initialLongitude, zoom: Float = initialZoom) {
     if (provider != null || mapWrapperView == null) return
 
     if (staticMode) {
@@ -146,7 +146,7 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
 
     applyProps()
 
-    google.initializeMap(mapWrapperView!!, initialLatitude, initialLongitude, initialZoom)
+    google.initializeMap(mapWrapperView!!, latitude, longitude, zoom)
 
     // Flush children mounted before provider was created
     for (i in 0 until childCount) {
@@ -369,6 +369,34 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
     duration: Int
   ) {
     provider?.fitCoordinates(coordinates, edgeInsetsTop, edgeInsetsLeft, edgeInsetsBottom, edgeInsetsRight, duration)
+  }
+
+  // Loads the map again, e.g. to recover from missing tiles. The SDK can't
+  // reload tiles in place, so the map is recreated at the current camera
+  // (coordinate and zoom; bearing and tilt reset) with children re-added
+  fun reload() {
+    val current = provider ?: return
+    val latitude = current.cameraLatitude
+    val longitude = current.cameraLongitude
+    val zoom = current.cameraZoom
+
+    // Children keep their native marker/overlay objects from the old map;
+    // detach them so the new provider creates fresh ones on the flush
+    for (i in 0 until childCount) {
+      when (val child = getChildAt(i)) {
+        is LuggMarkerView -> current.removeMarkerView(child)
+        is LuggPolylineView -> current.removePolylineView(child)
+        is LuggPolygonView -> current.removePolygonView(child)
+        is LuggCircleView -> current.removeCircleView(child)
+        is LuggGroundOverlayView -> current.removeGroundOverlayView(child)
+        is LuggTileOverlayView -> current.removeTileOverlayView(child)
+      }
+    }
+    current.destroy()
+    provider = null
+    if (isAttachedToWindow) {
+      initializeProvider(latitude, longitude, zoom)
+    }
   }
 
   // endregion

--- a/android/src/main/java/com/luggmaps/LuggMapView.kt
+++ b/android/src/main/java/com/luggmaps/LuggMapView.kt
@@ -371,27 +371,12 @@ class LuggMapView(private val reactContext: ThemedReactContext) :
     provider?.fitCoordinates(coordinates, edgeInsetsTop, edgeInsetsLeft, edgeInsetsBottom, edgeInsetsRight, duration)
   }
 
-  // Loads the map again, e.g. to recover from missing tiles. The SDK can't
-  // reload tiles in place, so the map is recreated at the current camera
-  // (coordinate and zoom; bearing and tilt reset) with children re-added
   fun reload() {
     val current = provider ?: return
     val latitude = current.cameraLatitude
     val longitude = current.cameraLongitude
     val zoom = current.cameraZoom
 
-    // Children keep their native marker/overlay objects from the old map;
-    // detach them so the new provider creates fresh ones on the flush
-    for (i in 0 until childCount) {
-      when (val child = getChildAt(i)) {
-        is LuggMarkerView -> current.removeMarkerView(child)
-        is LuggPolylineView -> current.removePolylineView(child)
-        is LuggPolygonView -> current.removePolygonView(child)
-        is LuggCircleView -> current.removeCircleView(child)
-        is LuggGroundOverlayView -> current.removeGroundOverlayView(child)
-        is LuggTileOverlayView -> current.removeTileOverlayView(child)
-      }
-    }
     current.destroy()
     provider = null
     if (isAttachedToWindow) {

--- a/android/src/main/java/com/luggmaps/LuggMapViewManager.kt
+++ b/android/src/main/java/com/luggmaps/LuggMapViewManager.kt
@@ -273,6 +273,10 @@ class LuggMapViewManager :
     )
   }
 
+  override fun reload(view: LuggMapView) {
+    view.reload()
+  }
+
   companion object {
     const val NAME = "LuggMapView"
   }

--- a/android/src/main/java/com/luggmaps/LuggMapWrapperView.kt
+++ b/android/src/main/java/com/luggmaps/LuggMapWrapperView.kt
@@ -2,6 +2,7 @@ package com.luggmaps
 
 import android.annotation.SuppressLint
 import android.view.MotionEvent
+import android.view.View
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
 
@@ -31,6 +32,14 @@ class LuggMapWrapperView(context: ThemedReactContext) : ReactViewGroup(context) 
     super.requestLayout()
     if (relayoutChildOnRequest) {
       post(measureAndLayoutChild)
+    }
+  }
+
+  override fun onViewAdded(child: View) {
+    super.onViewAdded(child)
+    // A replacement map needs sizing even when Yoga's layout is unchanged.
+    if (indexOfChild(child) == 0) {
+      layoutChild(width, height)
     }
   }
 

--- a/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
+++ b/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
@@ -211,6 +211,9 @@ class GoogleMapProvider(private val context: Context) :
     groundOverlayToViewMap.clear()
     markerToViewMap.clear()
     wrapperView?.touchEventHandler = null
+    // The wrapper outlives the provider on reload; don't leave the dead map
+    // view in it
+    mapView?.let { wrapperView?.removeView(it) }
     wrapperView = null
     googleMap?.setOnCameraMoveStartedListener(null)
     googleMap?.setOnCameraMoveListener(null)
@@ -1198,6 +1201,24 @@ class GoogleMapProvider(private val context: Context) :
     pendingTileOverlayViews.forEach { syncTileOverlayView(it) }
     pendingTileOverlayViews.clear()
   }
+
+  // endregion
+
+  // region Camera
+
+  // A static map's camera is inset-shifted (staticCameraTarget), so report
+  // the requested camera instead
+  private val liveCameraPosition: CameraPosition?
+    get() = if (staticMode) null else googleMap?.cameraPosition
+
+  override val cameraLatitude: Double
+    get() = liveCameraPosition?.target?.latitude ?: initialLatitude
+
+  override val cameraLongitude: Double
+    get() = liveCameraPosition?.target?.longitude ?: initialLongitude
+
+  override val cameraZoom: Float
+    get() = liveCameraPosition?.zoom ?: initialZoom
 
   // endregion
 

--- a/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
+++ b/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
@@ -183,7 +183,7 @@ class GoogleMapProvider(private val context: Context) :
       view.onCreate(null)
       view.onResume()
       view.getMapAsync(this)
-      wrapper.addView(view)
+      wrapper.addView(view, 0)
     }
     wrapper.onLayoutReady = null
   }

--- a/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
+++ b/android/src/main/java/com/luggmaps/core/GoogleMapProvider.kt
@@ -128,6 +128,7 @@ class GoogleMapProvider(private val context: Context) :
 
   // Theme
   private var theme: String = "system"
+  private var mapType: String = "standard"
 
   // Edge Insets
   private var edgeInsets: EdgeInsets = EdgeInsets()
@@ -279,6 +280,7 @@ class GoogleMapProvider(private val context: Context) :
     applyZoomLimits()
     applyInsetAdjustment()
     applyTheme()
+    setMapType(mapType)
     applyUserLocation()
     processPendingMarkers()
     processPendingPolylines()
@@ -545,6 +547,7 @@ class GoogleMapProvider(private val context: Context) :
   }
 
   override fun setMapType(value: String) {
+    mapType = value
     googleMap?.mapType = when (value) {
       "satellite" -> GoogleMap.MAP_TYPE_SATELLITE
       "terrain" -> GoogleMap.MAP_TYPE_TERRAIN

--- a/android/src/main/java/com/luggmaps/core/MapProviderDelegate.kt
+++ b/android/src/main/java/com/luggmaps/core/MapProviderDelegate.kt
@@ -58,6 +58,11 @@ interface MapProvider {
   fun addTileOverlayView(tileOverlayView: LuggTileOverlayView)
   fun removeTileOverlayView(tileOverlayView: LuggTileOverlayView)
 
+  // Current camera (the initial camera until the map is ready)
+  val cameraLatitude: Double
+  val cameraLongitude: Double
+  val cameraZoom: Float
+
   // Lifecycle
   fun pauseAnimations()
   fun resumeAnimations()

--- a/docs/content/docs/components/map-view.mdx
+++ b/docs/content/docs/components/map-view.mdx
@@ -329,8 +329,9 @@ outage. None of the map SDKs can reload tiles in place, so:
 - A static map re-renders its base map. On iOS the cached snapshot for its
   `staticKey` is discarded and the new render replaces the current image
   when ready; on Android the lite map is recreated.
-- A live map is recreated at its current coordinate and zoom (heading and
-  pitch reset) with all children re-added, and `onReady` fires again.
+- A live map is recreated at its current coordinate and zoom. Heading and
+  pitch reset, and `onReady` fires again. Markers and overlays remain on
+  the map after reload.
 
 ```ts
 reload(): void

--- a/docs/content/docs/components/map-view.mdx
+++ b/docs/content/docs/components/map-view.mdx
@@ -333,6 +333,10 @@ outage. None of the map SDKs can reload tiles in place, so:
   pitch reset, and `onReady` fires again. Markers and overlays remain on
   the map after reload.
 
+Reload preserves the map type and edge insets. On web, `onReady` fires once
+for each new map instance. On iOS, an unfinished static reload restarts
+when the map leaves the window and returns.
+
 ```ts
 reload(): void
 ```

--- a/docs/content/docs/components/map-view.mdx
+++ b/docs/content/docs/components/map-view.mdx
@@ -119,7 +119,7 @@ Notes:
   reports the map stable with all tiles loaded. If tiles fail (e.g.
   offline), the live warmup map stays in place instead and renders again
   the next time the row appears, so a bad render can't get stuck behind
-  `staticKey`.
+  `staticKey`. To force it, call `reload()` on the ref.
 - Alternatively, keeping rows mounted (larger `windowSize` with
   `removeClippedSubviews`) avoids re-rendering entirely at the cost of
   holding every row's snapshot in memory.
@@ -278,6 +278,9 @@ mapRef.current?.setEdgeInsets(
   { top: 0, left: 0, bottom: 200, right: 0 },
   { duration: 300 }
 );
+
+// Load the map again (e.g. after a network outage)
+mapRef.current?.reload();
 ```
 
 ### moveCamera
@@ -316,6 +319,21 @@ setEdgeInsets(edgeInsets: EdgeInsets, options?: SetEdgeInsetsOptions): void
 interface SetEdgeInsetsOptions {
   duration?: number; // milliseconds, -1 for default animation, 0 for instant
 }
+```
+
+### reload
+
+Load the map again, e.g. to recover from missing tiles after a network
+outage. None of the map SDKs can reload tiles in place, so:
+
+- A static map re-renders its base map. On iOS the cached snapshot for its
+  `staticKey` is discarded and the new render replaces the current image
+  when ready; on Android the lite map is recreated.
+- A live map is recreated at its current coordinate and zoom (heading and
+  pitch reset) with all children re-added, and `onReady` fires again.
+
+```ts
+reload(): void
 ```
 
 ## Events

--- a/docs/content/docs/components/map-view.mdx
+++ b/docs/content/docs/components/map-view.mdx
@@ -115,6 +115,11 @@ Notes:
   re-render from props). The camera and map settings are part of the
   cache key automatically. Changing `staticKey` discards the current
   image and re-renders. The cache is bounded by count and total memory.
+- On iOS (Google), the base map is only captured and cached once the SDK
+  reports the map stable with all tiles loaded. If tiles fail (e.g.
+  offline), the live warmup map stays in place instead and renders again
+  the next time the row appears, so a bad render can't get stuck behind
+  `staticKey`.
 - Alternatively, keeping rows mounted (larger `windowSize` with
   `removeClippedSubviews`) avoids re-rendering entirely at the cost of
   holding every row's snapshot in memory.

--- a/example/shared/src/components/Map.tsx
+++ b/example/shared/src/components/Map.tsx
@@ -297,6 +297,7 @@ export const Map = memo(
           moveCamera: (...args) => mapRef.current?.moveCamera(...args),
           fitCoordinates: (...args) => mapRef.current?.fitCoordinates(...args),
           setEdgeInsets: (...args) => mapRef.current?.setEdgeInsets(...args),
+          reload: () => mapRef.current?.reload(),
           showMarkerCallout: (markerId) =>
             markerRefsMap.current.get(markerId)?.showCallout(),
           hideMarkerCallout: (markerId) =>

--- a/example/shared/src/screens/HomeScreen.tsx
+++ b/example/shared/src/screens/HomeScreen.tsx
@@ -95,13 +95,15 @@ const HomeContent = ({
   );
 
   const handleMapReady = useCallback(() => {
+    lockStatus();
+    setStatus({ text: 'Map ready', error: false });
     const position = controlSheetRef.current?.animatedPosition;
     if (!position) return;
     const bottom = screenHeight - position.value;
     if (bottom > 0) {
       mapRef.current?.setEdgeInsets(bottomEdgeInsets(bottom));
     }
-  }, [screenHeight]);
+  }, [lockStatus, screenHeight]);
 
   const handleSheetEvent = useCallback(
     (event: DetentChangeEvent) => {

--- a/example/shared/src/screens/HomeScreen.tsx
+++ b/example/shared/src/screens/HomeScreen.tsx
@@ -279,6 +279,7 @@ const HomeContent = ({
         onClearMarkers={clear}
         onMoveCamera={moveToRandomMarker}
         onFitMarkers={fitAllMarkers}
+        onReload={() => mapRef.current?.reload()}
         onToggleMap={() => setShowMap((prev) => !prev)}
         onToggleProvider={() =>
           setProvider((p) => (p === 'google' ? 'apple' : 'google'))

--- a/example/shared/src/screens/StaticMapsScreen.tsx
+++ b/example/shared/src/screens/StaticMapsScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import {
   FlatList,
   Platform,
@@ -262,6 +262,7 @@ const PlaceCard = ({
 }) => {
   const { colors } = useTheme();
   const { width } = useWindowDimensions();
+  const mapRef = useRef<MapView>(null);
 
   const camera = fittedCamera(
     placeCoordinates(place),
@@ -281,6 +282,7 @@ const PlaceCard = ({
     >
       <View style={styles.map} pointerEvents="none">
         <MapView
+          ref={mapRef}
           key={provider}
           staticMode
           staticKey={place.id}
@@ -293,6 +295,18 @@ const PlaceCard = ({
           <PlaceConstellation place={place} />
         </MapView>
       </View>
+      {/* Re-renders the base map, dropping its cached snapshot - e.g. to
+          recover a map that rendered with missing tiles */}
+      <Pressable
+        style={({ pressed }) => [
+          styles.reload,
+          { backgroundColor: colors.backgroundElevated },
+          pressed && styles.cardPressed,
+        ]}
+        onPress={() => mapRef.current?.reload()}
+      >
+        <ThemedText variant="caption">Reload</ThemedText>
+      </Pressable>
       <View style={styles.cardContent}>
         <ThemedText variant="title" style={styles.cardTitle}>
           {place.name}
@@ -360,6 +374,14 @@ const styles = StyleSheet.create({
   },
   map: {
     height: MAP_HEIGHT,
+  },
+  reload: {
+    position: 'absolute',
+    top: sizes.sm,
+    right: sizes.sm,
+    paddingHorizontal: sizes.md,
+    paddingVertical: sizes.xs,
+    borderRadius: sizes.radiusFull,
   },
   cardContent: {
     padding: sizes.lg,

--- a/example/shared/src/sheets/ControlSheet.tsx
+++ b/example/shared/src/sheets/ControlSheet.tsx
@@ -29,6 +29,7 @@ interface ControlSheetProps {
   onClearMarkers: () => void;
   onMoveCamera: () => void;
   onFitMarkers: () => void;
+  onReload: () => void;
   onToggleMap: () => void;
   onToggleProvider: () => void;
   onLoadGeojson: () => void;
@@ -56,6 +57,7 @@ export const ControlSheet = forwardRef<ControlSheetRef, ControlSheetProps>(
       onClearMarkers,
       onMoveCamera,
       onFitMarkers,
+      onReload,
       onToggleMap,
       onToggleProvider,
       onLoadGeojson,
@@ -121,6 +123,12 @@ export const ControlSheet = forwardRef<ControlSheetRef, ControlSheetProps>(
             title="Fit Markers"
             onPress={onFitMarkers}
             disabled={markerCount === 0}
+          />
+          <Button
+            style={styles.sheetButton}
+            title="Reload Map"
+            onPress={onReload}
+            disabled={!showMap}
           />
           <Button
             style={styles.sheetButton}

--- a/ios/LuggMapView.mm
+++ b/ios/LuggMapView.mm
@@ -594,6 +594,7 @@ static NSCache<NSString *, UIImage *> *StaticSnapshotCache(void) {
 // reset) with children re-added.
 - (void)reload {
   if (_staticMode) {
+    _staticSnapshotDone = NO;
     NSString *cacheKey = [self staticSnapshotCacheKey];
     if (cacheKey) {
       [StaticSnapshotCache() removeObjectForKey:cacheKey];
@@ -616,6 +617,13 @@ static NSCache<NSString *, UIImage *> *StaticSnapshotCache(void) {
   _provider = nil;
   _initialized = NO;
   [self initializeProviderWithCoordinate:coordinate zoom:zoom];
+  if (_providerType == LuggMapViewProvider::Apple) {
+    // The captured camera already includes the previous inset offset.
+    [_provider moveCamera:coordinate.latitude
+                longitude:coordinate.longitude
+                     zoom:zoom
+                 duration:0];
+  }
 }
 
 - (void)removeChildrenFromProvider {

--- a/ios/LuggMapView.mm
+++ b/ios/LuggMapView.mm
@@ -311,11 +311,20 @@ static NSCache<NSString *, UIImage *> *StaticSnapshotCache(void) {
 #pragma mark - Provider Initialization
 
 - (void)initializeProvider {
-  if (_provider || !_mapWrapperView)
-    return;
-
   const auto &viewProps =
       *std::static_pointer_cast<LuggMapViewProps const>(_props);
+  [self
+      initializeProviderWithCoordinate:CLLocationCoordinate2DMake(
+                                           viewProps.initialCoordinate.latitude,
+                                           viewProps.initialCoordinate
+                                               .longitude)
+                                  zoom:viewProps.initialZoom];
+}
+
+- (void)initializeProviderWithCoordinate:(CLLocationCoordinate2D)coordinate
+                                    zoom:(double)zoom {
+  if (_provider || !_mapWrapperView)
+    return;
 
   if (_providerType == LuggMapViewProvider::Apple) {
     _provider = _staticMode ? [[AppleStaticMapProvider alloc] init]
@@ -333,13 +342,9 @@ static NSCache<NSString *, UIImage *> *StaticSnapshotCache(void) {
   _provider.delegate = self;
   _provider.staticMode = _staticMode;
 
-  CLLocationCoordinate2D coordinate =
-      CLLocationCoordinate2DMake(viewProps.initialCoordinate.latitude,
-                                 viewProps.initialCoordinate.longitude);
-
   [_provider initializeMapInView:_mapWrapperView
                initialCoordinate:coordinate
-                     initialZoom:viewProps.initialZoom];
+                     initialZoom:zoom];
 
   // After initializeMapInView so the cache key reads the provider's camera;
   // the base render is async and picks up the cached image
@@ -580,6 +585,55 @@ static NSCache<NSString *, UIImage *> *StaticSnapshotCache(void) {
   [_provider setEdgeInsets:_edgeInsets
              oldEdgeInsets:oldInsets
                   duration:duration];
+}
+
+// Loads the map again, e.g. to recover from missing tiles. A static map
+// drops its cached snapshot and renders the base map again in place.
+// Neither SDK can reload a live map's tiles, so the native map view is
+// recreated at the current camera (coordinate and zoom; heading and pitch
+// reset) with children re-added.
+- (void)reload {
+  if (_staticMode) {
+    NSString *cacheKey = [self staticSnapshotCacheKey];
+    if (cacheKey) {
+      [StaticSnapshotCache() removeObjectForKey:cacheKey];
+    }
+    if ([_provider isKindOfClass:[StaticMapProviderBase class]]) {
+      [(StaticMapProviderBase *)_provider rerenderBaseMap];
+    }
+    return;
+  }
+
+  if (!_provider)
+    return;
+
+  CLLocationCoordinate2D coordinate = _provider.coordinate;
+  double zoom = _provider.zoom;
+  // Children keep their native marker/overlay objects from the old map;
+  // detach them so the new provider creates fresh ones on the flush
+  [self removeChildrenFromProvider];
+  [_provider destroy];
+  _provider = nil;
+  _initialized = NO;
+  [self initializeProviderWithCoordinate:coordinate zoom:zoom];
+}
+
+- (void)removeChildrenFromProvider {
+  for (UIView *subview in self.subviews) {
+    if ([subview isKindOfClass:[LuggMarkerView class]]) {
+      [_provider removeMarkerView:(LuggMarkerView *)subview];
+    } else if ([subview isKindOfClass:[LuggPolylineView class]]) {
+      [_provider removePolylineView:(LuggPolylineView *)subview];
+    } else if ([subview isKindOfClass:[LuggPolygonView class]]) {
+      [_provider removePolygonView:(LuggPolygonView *)subview];
+    } else if ([subview isKindOfClass:[LuggCircleView class]]) {
+      [_provider removeCircleView:(LuggCircleView *)subview];
+    } else if ([subview isKindOfClass:[LuggGroundOverlayView class]]) {
+      [_provider removeGroundOverlayView:(LuggGroundOverlayView *)subview];
+    } else if ([subview isKindOfClass:[LuggTileOverlayView class]]) {
+      [_provider removeTileOverlayView:(LuggTileOverlayView *)subview];
+    }
+  }
 }
 
 - (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args {

--- a/ios/core/AppleMapProvider.mm
+++ b/ios/core/AppleMapProvider.mm
@@ -221,6 +221,14 @@ static double tileToLng(NSInteger x, NSInteger z) {
   _isMapReady = NO;
 }
 
+- (CLLocationCoordinate2D)coordinate {
+  return _mapView.centerCoordinate;
+}
+
+- (double)zoom {
+  return _mapView.zoomLevel;
+}
+
 - (void)destroyMapView {
   [self dismissNonBubbledCallout];
   [self stopEdgeInsetsAnimation];

--- a/ios/core/GoogleMapProvider.mm
+++ b/ios/core/GoogleMapProvider.mm
@@ -183,6 +183,14 @@ LuggInterfaceStyleFromTheme(facebook::react::LuggMapViewTheme theme) {
   _mapView = nil;
 }
 
+- (CLLocationCoordinate2D)coordinate {
+  return _mapView.camera.target;
+}
+
+- (double)zoom {
+  return _mapView.camera.zoom;
+}
+
 #pragma mark - Props
 
 - (void)setZoomEnabled:(BOOL)enabled {

--- a/ios/core/GoogleStaticMapProvider.mm
+++ b/ios/core/GoogleStaticMapProvider.mm
@@ -49,7 +49,7 @@ static void EnqueueStaticMapView(NSString *mapId, GMSMapView *mapView) {
 
 @implementation GoogleStaticMapProvider {
   GMSMapView *_warmupMapView;
-  BOOL _tilesRendered;
+  BOOL _snapshotReady;
   BOOL _swapScheduled;
 }
 
@@ -106,7 +106,7 @@ static void EnqueueStaticMapView(NSString *mapId, GMSMapView *mapView) {
   if (!wrapperView)
     return;
 
-  _tilesRendered = NO;
+  _snapshotReady = NO;
 
   GMSMapView *mapView = DequeueStaticMapView([self poolKey]);
   if (mapView) {
@@ -152,12 +152,12 @@ static void EnqueueStaticMapView(NSString *mapId, GMSMapView *mapView) {
   _warmupMapView = nil;
 }
 
-// Once tiles are fully rendered, swap the live map with its image and
-// release the map view. The image render and map teardown are expensive,
-// so they run outside scroll tracking; the live map keeps displaying (and
-// loading tiles) until then.
+// Once the map is stable, swap the live map with its image and release the
+// map view. The image render and map teardown are expensive, so they run
+// outside scroll tracking; the live map keeps displaying (and loading
+// tiles) until then.
 - (void)scheduleSwap {
-  if (_swapScheduled || !_warmupMapView || !_tilesRendered ||
+  if (_swapScheduled || !_warmupMapView || !_snapshotReady ||
       !_warmupMapView.window)
     return;
 
@@ -176,9 +176,9 @@ static void EnqueueStaticMapView(NSString *mapId, GMSMapView *mapView) {
 
 - (void)performSwap {
   // Tiles can invalidate (or the view leave the window) between scheduling
-  // and this runloop pass; the next tile callback or resumeAnimations
+  // and this runloop pass; the next snapshotReady or resumeAnimations
   // retries
-  if (!_warmupMapView || !_tilesRendered || !_warmupMapView.window)
+  if (!_warmupMapView || !_snapshotReady || !_warmupMapView.window)
     return;
 
   UIImageView *imageView = [_warmupMapView lugg_snapshotImageView];
@@ -192,20 +192,24 @@ static void EnqueueStaticMapView(NSString *mapId, GMSMapView *mapView) {
 #pragma mark - GMSMapViewDelegate
 
 - (void)mapViewDidStartTileRendering:(GMSMapView *)mapView {
-  _tilesRendered = NO;
+  _snapshotReady = NO;
 }
 
+// Fires for tiles that failed permanently too, so it can't gate the swap:
+// capturing here cached blank tiles under the static key with no way to
+// recover. The visible warmup map has rendered what it can; show the
+// overlays now instead of waiting for the swap, which is deferred while
+// scrolling
 - (void)mapViewDidFinishTileRendering:(GMSMapView *)mapView {
-  _tilesRendered = YES;
-  // The visible warmup map is fully rendered; show the overlays now
-  // instead of waiting for the swap, which is deferred while scrolling
   [self revealOverlays];
-  [self scheduleSwap];
 }
 
+// Stable per the SDK: tiles loaded, labels and overlays rendered. The only
+// signal that the render is complete, so the only one that captures and
+// caches. Without it (e.g. offline) the live map stays until the view
+// leaves the window, and a fresh warmup runs on return.
 - (void)mapViewSnapshotReady:(GMSMapView *)mapView {
-  // Stable per the SDK: tiles loaded, labels and overlays rendered
-  _tilesRendered = YES;
+  _snapshotReady = YES;
   [self revealOverlays];
   [self scheduleSwap];
 }

--- a/ios/core/MapProviderDelegate.h
+++ b/ios/core/MapProviderDelegate.h
@@ -89,6 +89,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)removeTileOverlayView:(LuggTileOverlayView *)tileOverlayView;
 - (void)syncTileOverlayView:(LuggTileOverlayView *)tileOverlayView;
 
+// Current camera (the initial camera until the map is ready)
+@property(nonatomic, readonly) CLLocationCoordinate2D coordinate;
+@property(nonatomic, readonly) double zoom;
+
 // Lifecycle
 - (void)pauseAnimations;
 - (void)resumeAnimations;

--- a/ios/core/StaticMapProviderBase.h
+++ b/ios/core/StaticMapProviderBase.h
@@ -42,6 +42,11 @@ CGPoint LuggStaticPointForCoordinate(MKMapRect mapRect, CGSize size,
 /// delegate callbacks and marks the base render done.
 - (void)displayBaseImage:(UIImage *)image fromCache:(BOOL)fromCache;
 
+/// Discards any cached, displayed or in-flight base render and renders
+/// again at the current camera. The displayed image stays until the new
+/// one replaces it.
+- (void)rerenderBaseMap;
+
 /// Shows the marker and shape overlays (idempotent). Called automatically
 /// when the base image displays; subclasses whose base map is already
 /// visible earlier (e.g. a live warmup map) can call it sooner.

--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -80,6 +80,13 @@ export class MapView
     Commands.setEdgeInsets(ref, top, left, bottom, right, duration);
   }
 
+  reload() {
+    const ref = this.nativeRef.current;
+    if (!ref) return;
+
+    Commands.reload(ref);
+  }
+
   render() {
     const {
       provider,

--- a/src/MapView.types.ts
+++ b/src/MapView.types.ts
@@ -135,6 +135,13 @@ export interface MapViewRef {
     options?: FitCoordinatesOptions
   ): void;
   setEdgeInsets(edgeInsets: EdgeInsets, options?: SetEdgeInsetsOptions): void;
+  /**
+   * Loads the map again, e.g. to recover from missing tiles. A static map
+   * re-renders its base map, discarding the cached snapshot. A live map is
+   * recreated at its current coordinate and zoom (heading and pitch reset)
+   * and fires onReady again.
+   */
+  reload(): void;
 }
 
 /**

--- a/src/MapView.types.ts
+++ b/src/MapView.types.ts
@@ -224,7 +224,8 @@ export interface MapViewProps extends ViewProps {
    * remounted with the same key (and same size, provider, and map settings)
    * reuses its cached snapshot instead of rendering a live map again -
    * e.g. set it to your list item's id. The key must uniquely identify the
-   * map's content, including markers and other children.
+   * map's content, including markers and other children. Only fully loaded
+   * renders are cached.
    * Only used with staticMode.
    */
   staticKey?: string;

--- a/src/MapView.web.tsx
+++ b/src/MapView.web.tsx
@@ -131,6 +131,12 @@ export const MapView = memo(
     const isDraggingRef = useRef(false);
     const wasGesture = useRef(false);
     const prevEdgeInsets = useRef(edgeInsets);
+    // Bumped by reload() to remount the map at the camera captured then
+    const [reloadState, setReloadState] = useState<{
+      key: number;
+      center?: google.maps.LatLngLiteral;
+      zoom?: number;
+    }>({ key: 0 });
 
     const offsetCenter = useCallback(
       (
@@ -267,6 +273,18 @@ export const MapView = memo(
           options?: SetEdgeInsetsOptions
         ) {
           applyEdgeInsets(newEdgeInsets, options?.duration);
+        },
+
+        // The JS SDK can't reload tiles in place; remount the map at the
+        // current camera
+        reload() {
+          if (!map) return;
+
+          setReloadState((state) => ({
+            key: state.key + 1,
+            center: map.getCenter()?.toJSON(),
+            zoom: map.getZoom(),
+          }));
         },
       }),
       [map, initialZoom, offsetCenter, applyEdgeInsets]
@@ -481,10 +499,11 @@ export const MapView = memo(
       >
         <View ref={containerRef} style={style}>
           <Map
+            key={reloadState.key}
             id={id}
             mapId={mapId}
-            defaultCenter={defaultCenter}
-            defaultZoom={initialZoom}
+            defaultCenter={reloadState.center ?? defaultCenter}
+            defaultZoom={reloadState.zoom ?? initialZoom}
             minZoom={minZoom}
             maxZoom={maxZoom}
             mapTypeId={mapTypeId}

--- a/src/MapView.web.tsx
+++ b/src/MapView.web.tsx
@@ -127,7 +127,7 @@ export const MapView = memo(
     const id = useId();
     const map = useMap(id);
     const containerRef = useRef<View>(null);
-    const readyFired = useRef(false);
+    const readyMap = useRef<google.maps.Map | null>(null);
     const isDraggingRef = useRef(false);
     const wasGesture = useRef(false);
     const prevEdgeInsets = useRef(edgeInsets);
@@ -291,8 +291,8 @@ export const MapView = memo(
     );
 
     useEffect(() => {
-      if (map && !readyFired.current) {
-        readyFired.current = true;
+      if (map && readyMap.current !== map) {
+        readyMap.current = map;
         onReady?.();
       }
     }, [map, onReady]);

--- a/src/fabric/LuggMapViewNativeComponent.ts
+++ b/src/fabric/LuggMapViewNativeComponent.ts
@@ -120,10 +120,16 @@ interface NativeCommands {
     right: Double,
     duration: Double
   ) => void;
+  reload: (viewRef: React.ElementRef<ComponentType>) => void;
 }
 
 export const Commands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['moveCamera', 'fitCoordinates', 'setEdgeInsets'],
+  supportedCommands: [
+    'moveCamera',
+    'fitCoordinates',
+    'setEdgeInsets',
+    'reload',
+  ],
 });
 
 export default codegenNativeComponent<NativeProps>(


### PR DESCRIPTION
## Summary

Add `MapView.reload()` on iOS, Android, and web to recover maps with missing tiles. Live maps retain their coordinate and zoom, reset heading and pitch, and emit `onReady` again. Static maps render again and invalidate cached iOS snapshots.

Capture Google iOS static snapshots only after `mapViewSnapshotReady`. Add reload controls and ready-event logging to the examples.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Android live reload and example ready-event logging confirmed by the author.
- Typecheck, targeted ESLint, Kotlin lint, formatting, and diff checks passed.
- iOS/web runtime behavior and static offline recovery still need verification. No builds run.

## Screenshots / Videos

None.

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
