### PR TITLE
Add flag to exclude Google Maps SDK in iOS

### DIFF
--- a/LuggMaps.podspec
+++ b/LuggMaps.podspec
@@ -24,6 +24,10 @@ Pod::Spec.new do |s|
   if google_enabled
     s.dependency "GoogleMaps"
   else
+    unless defined?($LuggMapsGoogleDisabledLogged)
+      Pod::UI.puts "[LuggMaps] Google Maps SDK is disabled, Apple Maps only.".yellow
+      $LuggMapsGoogleDisabledLogged = true
+    end
     s.exclude_files = "ios/core/Google*", "ios/core/GMS*"
   end
   s.frameworks = "MapKit"

--- a/LuggMaps.podspec
+++ b/LuggMaps.podspec
@@ -16,7 +16,13 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift,cpp}"
   s.private_header_files = "ios/**/*.h"
 
-  s.dependency "GoogleMaps"
+  # `$LuggMapsGoogleEnabled = false` in the Podfile drops the Google Maps SDK (Apple Maps only)
+  google_enabled = defined?($LuggMapsGoogleEnabled) ? $LuggMapsGoogleEnabled : true
+  if google_enabled
+    s.dependency "GoogleMaps"
+  else
+    s.exclude_files = "ios/core/Google*", "ios/core/GMS*"
+  end
   s.frameworks = "MapKit"
 
   install_modules_dependencies(s)

--- a/LuggMaps.podspec
+++ b/LuggMaps.podspec
@@ -18,6 +18,9 @@ Pod::Spec.new do |s|
 
   # `$LuggMapsGoogleEnabled = false` in the Podfile drops the Google Maps SDK (Apple Maps only)
   google_enabled = defined?($LuggMapsGoogleEnabled) ? $LuggMapsGoogleEnabled : true
+  s.pod_target_xcconfig = {
+    "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) LUGG_GOOGLE_MAPS_ENABLED=#{google_enabled ? 1 : 0}"
+  }
   if google_enabled
     s.dependency "GoogleMaps"
   else

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -57,6 +57,16 @@ Apple Maps works out of the box on iOS. Google Maps requires an API key on every
     cd ios && pod install
     ```
 
+    #### Apple Maps only
+
+    If you only use `provider="apple"` on iOS, you can skip the Google Maps SDK entirely (it adds roughly 10 MB to the app). Set this at the top of your `Podfile` before running `pod install`:
+
+    ```ruby title="Podfile"
+    $LuggMapsGoogleEnabled = false
+    ```
+
+    With the SDK excluded, a `MapView` requesting `provider="google"` falls back to Apple Maps and logs a warning.
+
     ### Android
 
     Add your Google Maps API key to `AndroidManifest.xml`:

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -38,6 +38,22 @@ Apple Maps works out of the box on iOS. Google Maps requires an API key on every
     ```sh
     npx expo prebuild --clean
     ```
+
+    #### Apple Maps only
+
+    If you only use `provider="apple"` on iOS, set `iosGoogleMapsEnabled` to `false` to skip the Google Maps SDK entirely (it adds roughly 10 MB to the app). The plugin writes `$LuggMapsGoogleEnabled = false` to your `Podfile` and `iosGoogleMapsApiKey` is ignored:
+
+    ```json title="app.json"
+    [
+      "@lugg/maps",
+      {
+        "iosGoogleMapsEnabled": false,
+        "androidGoogleMapsApiKey": "YOUR_ANDROID_API_KEY"
+      }
+    ]
+    ```
+
+    With the SDK excluded, a `MapView` requesting `provider="google"` falls back to Apple Maps and logs a warning.
   </Tab>
   <Tab value="Bare React Native">
     ### iOS

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -41,7 +41,7 @@ Apple Maps works out of the box on iOS. Google Maps requires an API key on every
 
     #### Apple Maps only
 
-    If you only use `provider="apple"` on iOS, set `iosGoogleMapsEnabled` to `false` to skip the Google Maps SDK entirely (it adds roughly 10 MB to the app). The plugin writes `$LuggMapsGoogleEnabled = false` to your `Podfile` and `iosGoogleMapsApiKey` is ignored:
+    If you only use Apple Maps on iOS, set `iosGoogleMapsEnabled` to `false` to exclude the Google Maps SDK:
 
     ```json title="app.json"
     [
@@ -52,6 +52,10 @@ Apple Maps works out of the box on iOS. Google Maps requires an API key on every
       }
     ]
     ```
+
+    The plugin ignores `iosGoogleMapsApiKey` and removes the Google Maps initialization from `AppDelegate.swift`.
+    After changing this option, run `npx expo prebuild --platform ios` and rebuild your app.
+    To enable Google Maps again, set `iosGoogleMapsEnabled` to `true` and provide `iosGoogleMapsApiKey`.
 
     With the SDK excluded, a `MapView` requesting `provider="google"` falls back to Apple Maps and logs a warning.
   </Tab>
@@ -75,11 +79,15 @@ Apple Maps works out of the box on iOS. Google Maps requires an API key on every
 
     #### Apple Maps only
 
-    If you only use `provider="apple"` on iOS, you can skip the Google Maps SDK entirely (it adds roughly 10 MB to the app). Set this at the top of your `Podfile` before running `pod install`:
+    If you only use Apple Maps on iOS, add this flag at the top of your `Podfile`:
 
     ```ruby title="Podfile"
     $LuggMapsGoogleEnabled = false
     ```
+
+    Remove `import GoogleMaps` and `GMSServices.provideAPIKey(...)` from `AppDelegate.swift`.
+    Then run `pod install` and rebuild your app.
+    To enable Google Maps again, remove the flag and restore the API key initialization before running `pod install`.
 
     With the SDK excluded, a `MapView` requesting `provider="google"` falls back to Apple Maps and logs a warning.
 

--- a/ios/LuggMapView.mm
+++ b/ios/LuggMapView.mm
@@ -8,8 +8,11 @@
 #import "LuggTileOverlayView.h"
 #import "core/AppleMapProvider.h"
 #import "core/AppleStaticMapProvider.h"
+#if __has_include(<GoogleMaps/GoogleMaps.h>)
+#define LUGG_GOOGLE_MAPS_AVAILABLE 1
 #import "core/GoogleMapProvider.h"
 #import "core/GoogleStaticMapProvider.h"
+#endif
 #import "core/MapProviderDelegate.h"
 #import "events/CameraIdleEvent.h"
 #import "events/CameraMoveEvent.h"
@@ -329,6 +332,7 @@ static NSCache<NSString *, UIImage *> *StaticSnapshotCache(void) {
   if (_providerType == LuggMapViewProvider::Apple) {
     _provider = _staticMode ? [[AppleStaticMapProvider alloc] init]
                             : [[AppleMapProvider alloc] init];
+#if LUGG_GOOGLE_MAPS_AVAILABLE
   } else if (_staticMode) {
     GoogleStaticMapProvider *google = [[GoogleStaticMapProvider alloc] init];
     google.mapId = _mapId;
@@ -338,6 +342,14 @@ static NSCache<NSString *, UIImage *> *StaticSnapshotCache(void) {
     google.mapId = _mapId;
     _provider = google;
   }
+#else
+  } else {
+    NSLog(@"[LuggMaps] provider=\"google\" requested but the Google Maps SDK "
+          @"is excluded ($LuggMapsGoogleEnabled = false); using Apple Maps");
+    _provider = _staticMode ? [[AppleStaticMapProvider alloc] init]
+                            : [[AppleMapProvider alloc] init];
+  }
+#endif
 
   _provider.delegate = self;
   _provider.staticMode = _staticMode;

--- a/ios/LuggMapView.mm
+++ b/ios/LuggMapView.mm
@@ -8,8 +8,7 @@
 #import "LuggTileOverlayView.h"
 #import "core/AppleMapProvider.h"
 #import "core/AppleStaticMapProvider.h"
-#if __has_include(<GoogleMaps/GoogleMaps.h>)
-#define LUGG_GOOGLE_MAPS_AVAILABLE 1
+#if LUGG_GOOGLE_MAPS_ENABLED
 #import "core/GoogleMapProvider.h"
 #import "core/GoogleStaticMapProvider.h"
 #endif
@@ -332,7 +331,7 @@ static NSCache<NSString *, UIImage *> *StaticSnapshotCache(void) {
   if (_providerType == LuggMapViewProvider::Apple) {
     _provider = _staticMode ? [[AppleStaticMapProvider alloc] init]
                             : [[AppleMapProvider alloc] init];
-#if LUGG_GOOGLE_MAPS_AVAILABLE
+#if LUGG_GOOGLE_MAPS_ENABLED
   } else if (_staticMode) {
     GoogleStaticMapProvider *google = [[GoogleStaticMapProvider alloc] init];
     google.mapId = _mapId;
@@ -629,7 +628,7 @@ static NSCache<NSString *, UIImage *> *StaticSnapshotCache(void) {
   _provider = nil;
   _initialized = NO;
   [self initializeProviderWithCoordinate:coordinate zoom:zoom];
-  if (_providerType == LuggMapViewProvider::Apple) {
+  if ([_provider isKindOfClass:[AppleMapProvider class]]) {
     // The captured camera already includes the previous inset offset.
     [_provider moveCamera:coordinate.latitude
                 longitude:coordinate.longitude

--- a/plugin/__tests__/withLuggMapsIOS.test.ts
+++ b/plugin/__tests__/withLuggMapsIOS.test.ts
@@ -1,0 +1,128 @@
+import type {
+  ExportedConfig,
+  InfoPlist,
+  IOSConfig,
+  Mod,
+} from '@expo/config-plugins';
+
+import {
+  type MapsIOSPluginProps,
+  withLuggMapsIOS,
+} from '../src/withLuggMapsIOS';
+
+const nativeFiles = {
+  podfile: "platform :ios, '15.1'\n",
+  appDelegate: `import Expo
+class AppDelegate {
+  func application(_ application: UIApplication) -> Bool {
+    return true
+  }
+}
+`,
+  infoPlist: { CFBundleDisplayName: 'Maps' } as InfoPlist,
+};
+
+async function runMod<T>(mod: Mod<T> | undefined, modResults: T) {
+  if (!mod) {
+    return modResults;
+  }
+
+  const config = { name: 'Maps', slug: 'maps' };
+  const result = await mod({
+    ...config,
+    modResults,
+    modRawConfig: config,
+    modRequest: {
+      projectRoot: '/tmp/maps',
+      platformProjectRoot: '/tmp/maps/ios',
+      platform: 'ios',
+      modName: 'test',
+      introspect: false,
+    },
+  });
+  return result.modResults;
+}
+
+async function applyPlugin(props: MapsIOSPluginProps, files = nativeFiles) {
+  const config: ExportedConfig = withLuggMapsIOS(
+    { name: 'Maps', slug: 'maps' },
+    props
+  );
+  const mods = config.mods?.ios;
+  const podfileMod = (
+    mods as { podfile?: Mod<IOSConfig.Paths.PodfileProjectFile> }
+  )?.podfile;
+  const podfile = await runMod(podfileMod, {
+    path: '/tmp/maps/ios/Podfile',
+    language: 'rb' as const,
+    contents: files.podfile,
+  });
+  const appDelegate = await runMod(mods?.appDelegate, {
+    path: '/tmp/maps/ios/AppDelegate.swift',
+    language: 'swift' as const,
+    contents: files.appDelegate,
+  });
+  const infoPlist = await runMod(mods?.infoPlist, { ...files.infoPlist });
+  return {
+    podfile: podfile.contents,
+    appDelegate: appDelegate.contents,
+    infoPlist,
+  };
+}
+
+it('keeps Google Maps enabled by default', async () => {
+  const files = await applyPlugin({ apiKey: 'test-key' });
+  expect(files.podfile).toBe(nativeFiles.podfile);
+  expect(files.appDelegate).toContain('import GoogleMaps');
+  expect(files.appDelegate).toContain('GMSServices.provideAPIKey("test-key")');
+  expect(files.infoPlist.GMSApiKey).toBe('test-key');
+});
+
+it('excludes Google Maps on a fresh project even when an API key is provided', async () => {
+  const files = await applyPlugin({ googleEnabled: false, apiKey: 'test-key' });
+  expect(files.podfile).toBe(
+    `$LuggMapsGoogleEnabled = false\n${nativeFiles.podfile}`
+  );
+  expect(files.appDelegate).toBe(nativeFiles.appDelegate);
+  expect(files.infoPlist).toEqual(nativeFiles.infoPlist);
+});
+
+it('removes Google Maps initialization when disabling an existing project', async () => {
+  const enabled = await applyPlugin({ apiKey: 'test-key' });
+  const disabled = await applyPlugin({ googleEnabled: false }, enabled);
+  expect(disabled.podfile).toContain('$LuggMapsGoogleEnabled = false');
+  expect(disabled.appDelegate).toBe(nativeFiles.appDelegate);
+  expect(disabled.infoPlist).toEqual(nativeFiles.infoPlist);
+});
+
+it.each([true, undefined])(
+  'restores Google Maps after disabling it (googleEnabled=%s)',
+  async (googleEnabled) => {
+    const disabled = await applyPlugin({ googleEnabled: false });
+    const enabled = await applyPlugin(
+      { googleEnabled, apiKey: 'test-key' },
+      disabled
+    );
+    expect(enabled.podfile).toBe(nativeFiles.podfile);
+    expect(enabled.appDelegate).toContain('import GoogleMaps');
+    expect(enabled.appDelegate).toContain(
+      'GMSServices.provideAPIKey("test-key")'
+    );
+    expect(enabled.infoPlist.GMSApiKey).toBe('test-key');
+  }
+);
+
+it('removes the exclusion flag without requiring an API key', async () => {
+  const disabled = await applyPlugin({ googleEnabled: false });
+  const enabled = await applyPlugin({ googleEnabled: true }, disabled);
+  expect(enabled).toEqual(nativeFiles);
+});
+
+it.each([true, false])(
+  'can run repeatedly without changing the result (googleEnabled=%s)',
+  async (googleEnabled) => {
+    const props = { googleEnabled, apiKey: 'test-key' };
+    const files = await applyPlugin(props);
+    expect(await applyPlugin(props, files)).toEqual(files);
+  }
+);

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -17,12 +17,25 @@ export interface MapsPluginProps {
    * Required for Android as it only supports Google Maps.
    */
   androidGoogleMapsApiKey?: string;
+
+  /**
+   * Whether to link the Google Maps SDK on iOS. Set to `false` when only
+   * Apple Maps is used to drop the SDK from the app. Defaults to `true`.
+   */
+  iosGoogleMapsEnabled?: boolean;
 }
 
 const withMaps: ConfigPlugin<MapsPluginProps | void> = (config, props = {}) => {
-  const { iosGoogleMapsApiKey, androidGoogleMapsApiKey } = props ?? {};
+  const {
+    iosGoogleMapsApiKey,
+    androidGoogleMapsApiKey,
+    iosGoogleMapsEnabled = true,
+  } = props ?? {};
 
-  config = withLuggMapsIOS(config, { apiKey: iosGoogleMapsApiKey });
+  config = withLuggMapsIOS(config, {
+    apiKey: iosGoogleMapsApiKey,
+    googleEnabled: iosGoogleMapsEnabled,
+  });
   config = withLuggMapsAndroid(config, { apiKey: androidGoogleMapsApiKey });
 
   return config;

--- a/plugin/src/withLuggMapsIOS.ts
+++ b/plugin/src/withLuggMapsIOS.ts
@@ -2,16 +2,29 @@ import {
   type ConfigPlugin,
   withInfoPlist,
   withAppDelegate,
+  withPodfile,
 } from '@expo/config-plugins';
 
 export interface MapsIOSPluginProps {
   apiKey?: string;
+  googleEnabled?: boolean;
 }
+
+const GMS_EXCLUSION_PODFILE_FLAG = '$LuggMapsGoogleEnabled = false';
 
 export const withLuggMapsIOS: ConfigPlugin<MapsIOSPluginProps> = (
   config,
-  { apiKey }
+  { apiKey, googleEnabled = true }
 ) => {
+  if (!googleEnabled) {
+    return withPodfile(config, (c) => {
+      if (!c.modResults.contents.includes(GMS_EXCLUSION_PODFILE_FLAG)) {
+        c.modResults.contents = `${GMS_EXCLUSION_PODFILE_FLAG}\n${c.modResults.contents}`;
+      }
+      return c;
+    });
+  }
+
   if (!apiKey) {
     return config;
   }

--- a/plugin/src/withLuggMapsIOS.ts
+++ b/plugin/src/withLuggMapsIOS.ts
@@ -17,6 +17,10 @@ export const withLuggMapsIOS: ConfigPlugin<MapsIOSPluginProps> = (
   { apiKey, googleEnabled = true }
 ) => {
   config = withPodfile(config, (c) => {
+    if (!googleEnabled) {
+      console.log('[LuggMaps] Google Maps SDK is disabled, Apple Maps only.');
+    }
+
     const contents = c.modResults.contents.replace(
       /^\$LuggMapsGoogleEnabled = false\r?\n/gm,
       ''

--- a/plugin/src/withLuggMapsIOS.ts
+++ b/plugin/src/withLuggMapsIOS.ts
@@ -16,25 +16,38 @@ export const withLuggMapsIOS: ConfigPlugin<MapsIOSPluginProps> = (
   config,
   { apiKey, googleEnabled = true }
 ) => {
-  if (!googleEnabled) {
-    return withPodfile(config, (c) => {
-      if (!c.modResults.contents.includes(GMS_EXCLUSION_PODFILE_FLAG)) {
-        c.modResults.contents = `${GMS_EXCLUSION_PODFILE_FLAG}\n${c.modResults.contents}`;
-      }
-      return c;
-    });
-  }
+  config = withPodfile(config, (c) => {
+    const contents = c.modResults.contents.replace(
+      /^\$LuggMapsGoogleEnabled = false\r?\n/gm,
+      ''
+    );
+    c.modResults.contents = googleEnabled
+      ? contents
+      : `${GMS_EXCLUSION_PODFILE_FLAG}\n${contents}`;
+    return c;
+  });
 
-  if (!apiKey) {
+  if (googleEnabled && !apiKey) {
     return config;
   }
 
   config = withInfoPlist(config, (c) => {
-    c.modResults.GMSApiKey = apiKey;
+    if (googleEnabled) {
+      c.modResults.GMSApiKey = apiKey;
+    } else {
+      delete c.modResults.GMSApiKey;
+    }
     return c;
   });
 
   config = withAppDelegate(config, (c) => {
+    if (!googleEnabled) {
+      c.modResults.contents = c.modResults.contents
+        .replace(/^[ \t]*import GoogleMaps\r?\n/gm, '')
+        .replace(/^[ \t]*GMSServices\.provideAPIKey\("[^"\r\n]*"\)\r?\n/gm, '');
+      return c;
+    }
+
     const contents = c.modResults.contents;
 
     // Add import for GoogleMaps
@@ -49,7 +62,7 @@ export const withLuggMapsIOS: ConfigPlugin<MapsIOSPluginProps> = (
     if (!c.modResults.contents.includes('GMSServices.provideAPIKey')) {
       c.modResults.contents = c.modResults.contents.replace(
         /(func application\([^)]+\)[^{]*\{)/,
-        `$1\n    GMSServices.provideAPIKey("${apiKey}")\n`
+        `$1\n    GMSServices.provideAPIKey("${apiKey}")`
       );
     }
 


### PR DESCRIPTION
## Summary

Add `$LuggMapsGoogleEnabled` Podfile flag to opt out of the Google Maps iOS SDK. Apps that only use `provider="apple"` currently still link `GoogleMaps.xcframework` (~36 MB arm64 slice, ~10 MB shipped). Setting `$LuggMapsGoogleEnabled = false` before `pod install` drops the dependency and excludes the Google provider sources; `LuggMapView.mm` guards the Google branches with `__has_include` and falls back to Apple Maps with a warning if `provider="google"` is requested anyway. Default behaviour is unchanged.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

`pod install` with the flag set in a bare RN 0.86 / Expo 57 app: `GoogleMaps` removed from `Podfile.lock`, project compiles and Apple Maps renders. Without the flag: unchanged lock file.

## Screenshots / Videos

N/A

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)